### PR TITLE
Shairport as a service

### DIFF
--- a/scripts/configure.sh
+++ b/scripts/configure.sh
@@ -57,4 +57,8 @@ cp -r volumio/etc/network/* build/$BUILD/root/etc/network
 # Wpa Supplicant
 echo " " > build/$BUILD/root/etc/wpa_supplicant/wpa_supplicant.conf
 chmod 777 build/$BUILD/root/etc/wpa_supplicant/wpa_supplicant.conf
+
+#Shairport
+chmod volumio:volumio -R /etc/shairport*
+
 echo 'Done Copying Custom Volumio System Files'

--- a/volumio/etc/shairport-sync.conf
+++ b/volumio/etc/shairport-sync.conf
@@ -1,0 +1,9 @@
+general =
+{
+    name = "volumio";
+};
+
+alsa =
+{
+  output_device = "hw:1,0";
+};

--- a/volumio/etc/shairport-sync.conf.tmpl
+++ b/volumio/etc/shairport-sync.conf.tmpl
@@ -1,0 +1,9 @@
+general =
+{
+    name = "${name}";
+};
+
+alsa =
+{
+  output_device = "${device}";
+};

--- a/volumio/lib/systemd/system/airplay.service
+++ b/volumio/lib/systemd/system/airplay.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=ShairportSync AirTunes receiver
+After=sound.target
+Requires=avahi-daemon.service
+After=avahi-daemon.service
+
+[Service]
+ExecStart=/usr/local/bin/shairport-sync
+User=volumio
+Group=volumio
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
configure.sh: set proper permissions on /etc/shairport* configuration files (template + configuration file)
/etc/shairport-sync.conf and /etc/shairport-sync.conf.tmpl: the TMPL is used by volumio airplay plugin to create runtime airplay configuration with ALSA and system name
airplay.service: shairport systemd configuration