### PR TITLE
xu4 with initramsfs and overlay/ reorganized odroid repo

### DIFF
--- a/scripts/initramfs/init
+++ b/scripts/initramfs/init
@@ -133,7 +133,7 @@ if [ -e "/boot/resize-volumio-datapart" ]; then
 echo "Re-sizing Volumio data partition"
   END="$(parted -s /dev/mmcblk0 unit MB print free | grep Free | tail -1 | awk '{print $2}' | grep -o '[0-9]\+')"
   parted -s /dev/mmcblk0 resizepart 3 ${END}
-  e2fsck -f /dev/mmcblk0p3
+  e2fsck -fy /dev/mmcblk0p3
   resize2fs /dev/mmcblk0p3
   echo "Volumio data partition succesfully resized"
   parted -s /dev/mmcblk0 unit MB print

--- a/scripts/odroidcimage.sh
+++ b/scripts/odroidcimage.sh
@@ -51,13 +51,18 @@ sudo mkfs -F -t ext4 -L volumio_data "${DATA_PART}"
 sync
 
 echo "Preparing for the Odroid kernel/ platform files"
-if [ -d platforms-O ]
+if [ -d platforms-O/odroidc ]
 then 
-	echo "Platform-O folder already exists - keeping it"
+	echo "Platform folder already exists - keeping it"
+    # if you really want to re-clone from the repo, then delete the odroidc folder
+    # that will refresh all the odroid platforms, see below
 else
-	echo "Creating temporary folder and clone Odroid files from repo"
-	mkdir platforms-O
+	echo "Clone all Odroid files from repo"
 	git clone https://github.com/gkkpch/Platform-Odroid.git platforms-O
+	echo "Unpack the C1/C1+/C2 platform files"
+    cd platforms-O
+    tar xvfJ odroidc.tar.xz 
+    cd ..
 fi
 
 echo "Copying the bootloader"

--- a/scripts/odroidx2image.sh
+++ b/scripts/odroidx2image.sh
@@ -57,13 +57,18 @@ sudo mkfs -F -t ext4 -L volumio "${SYS_PART}"
 sync
 
 echo "Get the Odroid kernel/ platform files from repo"
-if [ -d platforms-O]
+if [ -d platforms-O/odroidx2 ]
 then 
-  echo "Platform-O folder already exists - keeping it"
+	echo "Platform folder already exists - keeping it"
+    # if you really want to re-clone from the repo, then delete the odroidx2 folder
+    # that will refresh all the odroid platforms, see below
 else
-  echo "remember CONFIG_FHANDLE=y Option sneeds to be set"
-  mkdir platforms-O
-  git clone https://github.com/gkkpch/Platform-Odroid.git platforms-O
+	echo "Clone all Odroid files from repo"
+	git clone https://github.com/gkkpch/Platform-Odroid.git platforms-O
+	echo "Unpack the X2 platform files"
+    cd platforms-O
+    tar xvfJ odroidx2.tar.xz 
+    cd ..
 fi
 
 echo "Copying the bootloader and trustzone software"


### PR DESCRIPTION
Changed the XU4 build to "standard" Volumio 2 requirements (initrd/ SD card resizing/ overlayfs/ squashfs and init- or remote-updater).
Reorganized odroid repo with one tarball per platform.