### PR TITLE
Add loadable sound modules to /etc/modules

### DIFF
--- a/scripts/odroidcconfig.sh
+++ b/scripts/odroidcconfig.sh
@@ -17,6 +17,14 @@ tmpfs   /tmp                    tmpfs   defaults,noatime,mode=0755 0 0
 tmpfs   /dev/shm                tmpfs   defaults        0 0
 " > /etc/fstab
 
+
+echo "Adding sound modules"
+#TODO: pcm5102 is needed, snd_soc_odroid_dac could be aded runtime (config?)
+echo "
+snd_soc_pcm5102
+snd_soc_odroid_dac
+" >> /etc/modules
+
 echo "Prevent services starting during install, running under chroot" 
 echo "(avoids unnecessary errors)"
 cat > /usr/sbin/policy-rc.d << EOF

--- a/scripts/odroidcconfig.sh
+++ b/scripts/odroidcconfig.sh
@@ -17,13 +17,15 @@ tmpfs   /tmp                    tmpfs   defaults,noatime,mode=0755 0 0
 tmpfs   /dev/shm                tmpfs   defaults        0 0
 " > /etc/fstab
 
-
-echo "Adding sound modules"
-#TODO: pcm5102 is needed, snd_soc_odroid_dac could be aded runtime (config?)
-echo "
+  
+if [ -e "/c2.flag" ]; then
+  echo "Adding sound modules"
+  #TODO: only works for C2 at the moment
+  echo "
 snd_soc_pcm5102
 snd_soc_odroid_dac
 " >> /etc/modules
+fi
 
 echo "Prevent services starting during install, running under chroot" 
 echo "(avoids unnecessary errors)"


### PR DESCRIPTION
Currently only works for Odroid C2, C1+ is to follow later.
(building with this script requires new Odroid C2 kernel --version 20160315-- to be cloned from repo!)