### PR TITLE
initramfs fix plus small build.sh improvement

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -35,8 +35,8 @@ function check_os_release {
   DEVICE=$3
 
   if [ "$HAS_VERSION" -ne "0" ]; then
-	# os-release already has a VERSION number
-    # cut the last 2 lines in other devices are being built from the same rootfs
+    # os-release already has a VERSION number
+    # cut the last 2 lines in case other devices are being built from the same rootfs
 	head -n -2 build/${ARCH_BUILD}/root/etc/os-release > build/${ARCH_BUILD}/root/etc/tmp-release
 	mv build/${ARCH_BUILD}/root/etc/tmp-release build/${ARCH_BUILD}/root/etc/os-release
   fi

--- a/build.sh
+++ b/build.sh
@@ -34,10 +34,14 @@ function check_os_release {
   VERSION=$2
   DEVICE=$3
 
-  if [ "$HAS_VERSION" -eq "0" ]; then
-    echo "VOLUMIO_VERSION=\"${VERSION}\"" >> build/${ARCH_BUILD}/root/etc/os-release
-    echo "VOLUMIO_HARDWARE=\"${DEVICE}\"" >> build/${ARCH_BUILD}/root/etc/os-release
+  if [ "$HAS_VERSION" -ne "0" ]; then
+	# os-release already has a VERSION number
+    # cut the last 2 lines in other devices are being built from the same rootfs
+	head -n -2 build/${ARCH_BUILD}/root/etc/os-release > build/${ARCH_BUILD}/root/etc/tmp-release
+	mv build/${ARCH_BUILD}/root/etc/tmp-release build/${ARCH_BUILD}/root/etc/os-release
   fi
+  echo "VOLUMIO_VERSION=\"${VERSION}\"" >> build/${ARCH_BUILD}/root/etc/os-release
+  echo "VOLUMIO_HARDWARE=\"${DEVICE}\"" >> build/${ARCH_BUILD}/root/etc/os-release
 }
 
 

--- a/scripts/initramfs/init
+++ b/scripts/initramfs/init
@@ -15,7 +15,6 @@ mknod /dev/null c 1 3
 mknod /dev/tty c 5 0
 mknod /dev/console c 5 1
 
-sleep 3
 mdev -s
 
 HWDEVICE="$(cat /proc/cpuinfo | grep Hardware | awk '{print $3}' )"
@@ -96,6 +95,18 @@ fi
 echo IMGPART=${IMGPART}
 echo IMGFILE=${IMGFILE}
 
+# Retry mdev -s 3 times before throwing the towel
+for i in 1 2 3 4 5 6
+  do
+    if [ ! -b "${IMGPART}" ]; then
+      echo  "${IMGPART} not detected,retrying mdev"
+      mdev -s
+    else
+	  blkid ${IMGPART}
+      break
+    fi
+  done
+
 if [ ! -b "${IMGPART}" ]; then
   echo "No partition with ${IMGPART} has been found"
   exec sh
@@ -116,8 +127,6 @@ if [ ! -e "/mnt/imgpart/volumio_factory.sqsh" ]; then
   echo "Factory image created"
 fi
 
-#sleep 6
-#mdev -s
 
 #Check eventually for USB updates (could be vfat or ext4 partion --> mount auto)
 echo "Check for USB updates"
@@ -152,6 +161,7 @@ losetup $loop_free /mnt/imgpart/${IMGFILE}
 [ -d /mnt/static ] || mkdir /mnt/static
 mount -t squashfs $loop_free /mnt/static
 
+VOLUMIO_VERSION="$(cat /mnt/static/etc/os-release | grep VOLUMIO_VERSION)"
 
 #if there is factory file then format data partition
 mkdir /mnt/factory
@@ -173,7 +183,6 @@ if [ -e "/mnt/factory/user_data" ]; then
 fi
 umount /mnt/factory
 rm -r /mnt/factory
-
 
 mkdir boot
 mount -t vfat /dev/mmcblk0p1 /boot
@@ -218,6 +227,7 @@ chmod -R 777 /mnt/ext/union/imgpart
 umount /proc
 umount /sys
 
+echo ${VOLUMIO_VERSION}
 echo "Finish initramfs, continue booting Volumio"
 exec switch_root /mnt/ext/union /sbin/init
 


### PR DESCRIPTION
This fixes a timing problem in the initrd by repeating the "mdev -s" command in case /dev/mmcblk0p2 cannot be detected. The fixed sleep period could be removed.
The build.sh script was adapted to make sure, /etc/os-release has the latest info related to the device and version being built. Especially important when the same rootfs is used for several devices.