### PR TITLE
GPIO pin permission fix

### DIFF
--- a/scripts/raspberryconfig.sh
+++ b/scripts/raspberryconfig.sh
@@ -80,6 +80,10 @@ groupadd -f --system gpio
 chgrp gpio /usr/local/bin/gpio-admin
 chmod u=rwxs,g=rx,o= /usr/local/bin/gpio-admin
 
+touch /lib/udev/rules.d/60-python-pifacecommon.rules
+echo 'KERNEL=="spidev*", GROUP="spi", MODE="0660"
+SUBSYSTEM=="gpio*", PROGRAM="/bin/sh -c' "'chown -R root:gpio /sys/class/gpio && chmod -R 770 /sys/class/gpio; chown -R root:gpio /sys/devices/virtual/gpio && chmod -R 770 /sys/devices/virtual/gpio; chown -R root:gpio /sys/devices/platform/soc/*.gpio/gpio && chmod -R 770 /sys/devices/platform/soc/*.gpio/gpio'"'"' > /lib/udev/rules.d/60-python-pifacecommon.rules
+
 echo "adding volumio to gpio group"
 sudo adduser volumio gpio
 


### PR DESCRIPTION
Root is currently needed to control GPIO pins. This fix solves it.
I have tested this on RPi 2 B. The gpio control files in /sys/class/gpio are correctly owned by group 'gpio' with the fix applied.

The fix is from [https://github.com/raspberrypi/linux/issues/1117#issuecomment-134227514](https://github.com/raspberrypi/linux/issues/1117#issuecomment-134227514). I was told it was already applied but can not find it anywhere on here.