### PR TITLE
Make calling rpi-update more robust

### DIFF
--- a/scripts/raspberryconfig.sh
+++ b/scripts/raspberryconfig.sh
@@ -54,7 +54,7 @@ mkdir /lib/modules
 # see https://github.com/raspberrypi/firmware/commit/cc6d7bf8b4c03a2a660ff9fdf4083fc165620866
 # and https://github.com/Hexxeh/rpi-firmware/issues/118
 
-echo y | SKIP_BACKUP=1 rpi-update 15ffab5493d74b12194e6bfc5bbb1c0f71140155
+echo y | SKIP_BACKUP=1 /usr/bin/rpi-update 15ffab5493d74b12194e6bfc5bbb1c0f71140155
 
 echo "Adding PI3 Wireless firmware"
 wget https://github.com/RPi-Distro/firmware-nonfree/raw/master/brcm80211/brcm/brcmfmac43430-sdio.bin -P /lib/firmware/brcm

--- a/scripts/raspberryconfig.sh
+++ b/scripts/raspberryconfig.sh
@@ -46,6 +46,7 @@ apt-get -y install binutils i2c-tools
 #apt-get -y install libnewt0.52 whiptail triggerhappy lua5.1 locales
 
 echo "Installing Kernel from Rpi-Update"
+[ -f /usr/bin/rpi-update ] && rm -f /usr/bin/rpi-update
 sudo curl -L --output /usr/bin/rpi-update https://raw.githubusercontent.com/Hexxeh/rpi-update/master/rpi-update && sudo chmod +x /usr/bin/rpi-update
 touch /boot/start.elf
 mkdir /lib/modules

--- a/scripts/raspberryconfig.sh
+++ b/scripts/raspberryconfig.sh
@@ -54,7 +54,7 @@ mkdir /lib/modules
 # see https://github.com/raspberrypi/firmware/commit/cc6d7bf8b4c03a2a660ff9fdf4083fc165620866
 # and https://github.com/Hexxeh/rpi-firmware/issues/118
 
-echo y | SKIP_BACKUP=1 /usr/bin/rpi-update 15ffab5493d74b12194e6bfc5bbb1c0f71140155
+echo y | SKIP_BACKUP=1 UPDATE_SELF=0 /usr/bin/rpi-update 15ffab5493d74b12194e6bfc5bbb1c0f71140155
 
 echo "Adding PI3 Wireless firmware"
 wget https://github.com/RPi-Distro/firmware-nonfree/raw/master/brcm80211/brcm/brcmfmac43430-sdio.bin -P /lib/firmware/brcm


### PR DESCRIPTION
I noticed that raspberryconfig.sh saves 'rpi-update' to a specific location but then calls it without that full path. Also, the code tries to self-update and self-execute, which seems like a complication we could do without. As I've been experimenting with the build code I had some runs fail to run rpi-update,
so I put this PR together to address the issue.