### PR TITLE
Use wget to download rpi-update

### DIFF
--- a/scripts/raspberryconfig.sh
+++ b/scripts/raspberryconfig.sh
@@ -46,7 +46,7 @@ apt-get -y install binutils i2c-tools
 #apt-get -y install libnewt0.52 whiptail triggerhappy lua5.1 locales
 
 echo "Installing Kernel from Rpi-Update"
-sudo curl -L --output /usr/bin/rpi-update https://raw.githubusercontent.com/Hexxeh/rpi-update/master/rpi-update && sudo chmod +x /usr/bin/rpi-update
+sudo wget -O /usr/bin/rpi-update https://raw.githubusercontent.com/Hexxeh/rpi-update/master/rpi-update && sudo chmod +x /usr/bin/rpi-update
 touch /boot/start.elf
 mkdir /lib/modules
 


### PR DESCRIPTION
I have had quite a lot of certificate validation errors with curl pulling down rpi-update, it was failing with
```
curl: (60) SSL certificate problem: unable to get local issuer certificate
```
I checked the certificates and ca-certificates.crt in the rootfs that was created by raspberryconfig.sh. Everything required was there and correct, I manually verified the certificate chain and root CA. I could not track down the issue that causes curl to fail. Switching to wget fixed the problem. Since this is the only place curl is actually used, this would seem to be the right answer.