### PR TITLE
Make sure the dtoverlay binaries have somewhere to go

### DIFF
--- a/scripts/raspberryimage.sh
+++ b/scripts/raspberryimage.sh
@@ -87,6 +87,7 @@ mount /proc /mnt/volumio/rootfs/proc -t proc
 mount /sys /mnt/volumio/rootfs/sys -t sysfs
 
 echo "Custom dtoverlay pre and post"
+mkdir -p /mnt/volumio/rootfs/opt/vc/bin/
 cp -rp volumio/opt/vc/bin/* /mnt/volumio/rootfs/opt/vc/bin/
 
 echo $PATCH > /mnt/volumio/rootfs/patch


### PR DESCRIPTION
At this point in the process, /mnt/volumio/rootfs/opt (copied from build/arm/root/opt) is empty.
Create the destination directory before copying the dtoverlay programs into it.

Without this change I get this error during build:
```
echo "Custom dtoverlay pre and post"
cp: target ‘/mnt/volumio/rootfs/opt/vc/bin/’ is not a directory
```