### PR TITLE
x86 boot improvement & initial cubox-i support

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -193,7 +193,8 @@ if [ "$DEVICE" = udoo ]; then
 fi
 if [ "$DEVICE" = cuboxi ]; then
   echo 'Writing Cubox-i Image File'
-  sh scripts/cuboxiimage.sh -v $VERSION;
+  check_os_release "arm" $VERSION $DEVICE
+  sh scripts/cuboxiimage.sh -v $VERSION -p $PATCH;
 fi
 if  [ "$DEVICE" = odroidc1 ]; then
   echo 'Writing Odroid-C1/C1+ Image File'

--- a/scripts/cuboxiconfig.sh
+++ b/scripts/cuboxiconfig.sh
@@ -1,0 +1,88 @@
+#!/bin/bash
+
+PATCH=$(cat /patch)
+
+# This script will be run in chroot under qemu.
+
+echo "Creating \"fstab\""
+echo "# cuboxi fstab" > /etc/fstab
+echo "" >> /etc/fstab
+echo "proc            /proc           proc    defaults        0       0
+/dev/mmcblk0p1  /boot           vfat    defaults,utf8,user,rw,umask=111,dmask=000        0       1
+tmpfs   /var/log                tmpfs   size=20M,nodev,uid=1000,mode=0777,gid=4, 0 0 
+tmpfs   /var/cache/apt/archives tmpfs   defaults,noexec,nosuid,nodev,mode=0755 0 0
+tmpfs   /var/spool/cups         tmpfs   defaults,noatime,mode=0755 0 0
+tmpfs   /var/spool/cups/tmp     tmpfs   defaults,noatime,mode=0755 0 0
+tmpfs   /tmp                    tmpfs   defaults,noatime,mode=0755 0 0
+tmpfs   /dev/shm                tmpfs   defaults        0 0
+" > /etc/fstab
+
+  
+#TODO: add sound modules
+echo "Adding sound modules"
+echo "
+.....
+.....
+" >> /etc/modules
+
+echo "Prevent services starting during install, running under chroot" 
+echo "(avoids unnecessary errors)"
+cat > /usr/sbin/policy-rc.d << EOF
+exit 101
+EOF
+chmod +x /usr/sbin/policy-rc.d
+
+echo "Installing additonal packages"
+apt-get update
+apt-get -y install u-boot-tools 
+
+echo "Cleaning APT Cache and remove policy file"
+rm -f /var/lib/apt/lists/*archive*
+apt-get clean
+rm /usr/sbin/policy-rc.d
+
+echo "Adding custom modules overlayfs, squashfs and nls_cp437"
+echo "overlay" >> /etc/initramfs-tools/modules
+echo "squashfs" >> /etc/initramfs-tools/modules
+echo "nls_cp437" >> /etc/initramfs-tools/modules
+
+echo "Copying volumio initramfs updater"
+cd /root/
+mv volumio-init-updater /usr/local/sbin
+
+#On The Fly Patch
+if [ "$PATCH" = "volumio" ]; then
+echo "No Patch To Apply"
+else
+echo "Applying Patch ${PATCH}"
+PATCHPATH=/${PATCH}
+cd $PATCHPATH
+#Check the existence of patch script
+if [ -f "patch.sh" ]; then
+sh patch.sh
+else
+echo "Cannot Find Patch File, aborting"
+fi
+cd /
+rm -rf ${PATCH}
+fi
+rm /patch
+
+#TODO: check initrd size
+echo "Changing to 'modules=dep'"
+echo "(otherwise cuboxi may not boot due to size of initrd)"
+sed -i "s/MODULES=most/MODULES=dep/g" /etc/initramfs-tools/initramfs.conf
+
+#First Boot operations
+echo "Signalling the init script to re-size the volumio data partition"
+touch /boot/resize-volumio-datapart
+
+echo "Creating initramfs 'volumio.initrd'"
+mkinitramfs-custom.sh -o /tmp/initramfs-tmp
+
+#TODO: check if it is OK to use uInitrd 
+echo "Creating uInitrd from 'volumio.initrd'"
+mkimage -A arm -O linux -T ramdisk -C none -a 0 -e 0 -n uInitrd -d /boot/volumio.initrd /boot/uInitrd
+
+echo "Removing unnecessary /boot files"
+rm /boot/volumio.initrd

--- a/scripts/cuboxiimage.sh
+++ b/scripts/cuboxiimage.sh
@@ -1,80 +1,173 @@
 #!/bin/sh
 
-
-while getopts ":v:" opt; do
+while getopts ":v:p:" opt; do
   case $opt in
     v)
       VERSION=$OPTARG
       ;;
+    p)
+      PATCH=$OPTARG
+      ;;
+
   esac
 done
-BUILDDATE=$(date -I)
-IMG_FILE="Volumio${VERSION}-${BUILDDATE}Cuboxi.img"
 
- 
-echo "Creating Image Bed"
+BUILDDATE=$(date -I)
+IMG_FILE="Volumio${VERSION}-${BUILDDATE}-cuboxi.img"
+
+
+echo "Creating Image File"
 echo "Image file: ${IMG_FILE}"
-dd if=/dev/zero of=${IMG_FILE} bs=1M count=1048
+dd if=/dev/zero of=${IMG_FILE} bs=1M count=1600
+
+echo "Creating Image Bed"
 LOOP_DEV=`sudo losetup -f --show ${IMG_FILE}`
  
 sudo parted -s "${LOOP_DEV}" mklabel msdos
-#sudo parted -s "${LOOP_DEV}p1" mkpart primary ext3 0 10
-sudo parted -s "${LOOP_DEV}" mkpart primary ext3 10 1048
+sudo parted -s "${LOOP_DEV}" mkpart primary fat32 1 64
+sudo parted -s "${LOOP_DEV}" mkpart primary ext3 65 1500
+sudo parted -s "${LOOP_DEV}" mkpart primary ext3 1500 100%
 sudo parted -s "${LOOP_DEV}" set 1 boot on
 sudo parted -s "${LOOP_DEV}" print
 sudo partprobe "${LOOP_DEV}"
-sudo kpartx -a "${LOOP_DEV}"
- 
-LOOP_PART=`echo /dev/mapper/"$( echo $LOOP_DEV | sed -e 's/.*\/\(\w*\)/\1/' )"p1`
+sudo kpartx -s -a "${LOOP_DEV}"
 
-if [ ! -b "$LOOP_PART" ]
+BOOT_PART=`echo /dev/mapper/"$( echo ${LOOP_DEV} | sed -e 's/.*\/\(\w*\)/\1/' )"p1`
+SYS_PART=`echo /dev/mapper/"$( echo ${LOOP_DEV} | sed -e 's/.*\/\(\w*\)/\1/' )"p2`
+DATA_PART=`echo /dev/mapper/"$( echo ${LOOP_DEV} | sed -e 's/.*\/\(\w*\)/\1/' )"p3`
+echo "Using: " ${BOOT_PART}
+echo "Using: " ${SYS_PART}
+echo "Using: " ${DATA_PART}
+if [ ! -b "${BOOT_PART}" ]
 then
-	echo "$LOOP_PART doesn't exist"
+	echo "${BOOT_PART} doesn't exist"
 	exit 1
 fi
 
-echo "Creating filesystems"
-sudo mkfs.ext4 -E stride=2,stripe-width=1024 -b 4096 "${LOOP_PART}" -L volumio
-sync
- 
-echo "Burning bootloader"
-sudo dd if=platforms/cuboxi/uboot/u-boot.img of=${LOOP_DEV} bs=512 seek=1
+echo "Creating boot and rootfs filesystems"
+sudo mkfs -t vfat -n BOOT "${BOOT_PART}"
+sudo mkfs -F -t ext4 -L volumio "${SYS_PART}"
+sudo mkfs -F -t ext4 -L volumio_data "${DATA_PART}"
 sync
 
- 
-echo "Copying Volumio RootFs"
-if [ -d /mnt ]; then
-	echo "/mnt/folder exist"
+echo "Preparing for the cubox kernel/ platform files"
+if [ -d platform-cuboxi ]
+then 
+	echo "Platform folder already exists - keeping it"
+    # if you really want to re-clone from the repo, then delete the platforms-cuboxi folder
+else
+	echo "Clone all cubox files from repo"
+	git clone https://github.com/gkkpch/platform-cuboxi.git platform-cuboxi
+	echo "Unpack the cubox platform files"
+    cd platform-cuboxi
+	tar xfJ cuboxi.tar.xz
+	cd ..
+fi
+
+#TODO: Check!!!!
+echo "Copying the bootloader"
+echo "Burning bootloader"
+sudo dd if=platform-cuboxi/cuboxi/uboot/SPL of=${LOOP_DEV} bs=1K seek=1
+sudo dd if=platform-cuboxi/cuboxi/uboot/u-boot.img of=${LOOP_DEV} bs=1K seek=42
+sync
+
+echo "Preparing for Volumio rootfs"
+if [ -d /mnt ]
+then 
+	echo "/mount folder exist"
 else
 	sudo mkdir /mnt
 fi
-
-if [ -d /mnt/volumio ]; then
+if [ -d /mnt/volumio ]
+then 
 	echo "Volumio Temp Directory Exists - Cleaning it"
 	rm -rf /mnt/volumio/*
 else
 	echo "Creating Volumio Temp Directory"
 	sudo mkdir /mnt/volumio
 fi
-sudo mount -t ext4 "${LOOP_PART}" /mnt/volumio
-sudo rm -rf /mnt/volumio/*
-sudo cp -pdR build/arm/root/* /mnt/volumio
+
+echo "Creating mount point for the images partition"
+mkdir /mnt/volumio/images
+sudo mount -t ext4 "${SYS_PART}" /mnt/volumio/images
+sudo mkdir /mnt/volumio/rootfs
+sudo mkdir /mnt/volumio/rootfs/boot
+sudo mount -t vfat "${BOOT_PART}" /mnt/volumio/rootfs/boot
+
+echo "Copying Volumio RootFs"
+sudo cp -pdR build/arm/root/* /mnt/volumio/rootfs
+echo "Copying cuboxi boot files, Kernel, Modules and Firmware"
+sudo cp platform-cuboxi/cuboxi/boot/* /mnt/volumio/rootfs/boot
+sudo cp -pdR platform-cuboxi/cuboxi/lib/modules /mnt/volumio/rootfs/lib
+sudo cp -pdR platform-cuboxi/cuboxi/lib/firmware /mnt/volumio/rootfs/lib
 
 sync
 
-echo "Copying Kernel"
-sudo cp -pdR platforms/cuboxi/boot /mnt/volumio/
- 
-echo "Copying Modules and Firmwares"
-sudo cp -pdR platforms/cuboxi/lib/modules /mnt/volumio/lib/modules
-sudo cp -pdR platforms/cuboxi/firmware /mnt/volumio/lib/firmware
+echo "Preparing to run chroot for more cuboxi configuration"
+cp scripts/cuboxiconfig.sh /mnt/volumio/rootfs
+cp scripts/initramfs/init /mnt/volumio/rootfs/root
+cp scripts/initramfs/mkinitramfs-custom.sh /mnt/volumio/rootfs/usr/local/sbin
+#copy the scripts for updating from usb
+wget -P /mnt/volumio/rootfs/root http://repo.volumio.org/Volumio2/Binaries/volumio-init-updater
+
+mount /dev /mnt/volumio/rootfs/dev -o bind
+mount /proc /mnt/volumio/rootfs/proc -t proc
+mount /sys /mnt/volumio/rootfs/sys -t sysfs
+echo $PATCH > /mnt/volumio/rootfs/patch
+chroot /mnt/volumio/rootfs /bin/bash -x <<'EOF'
+su -
+/cuboxiconfig.sh
+EOF
+
+#cleanup
+rm /mnt/volumio/rootfs/cuboxiconfig.sh /mnt/volumio/rootfs/root/init
+
+echo "Unmounting Temp devices"
+umount -l /mnt/volumio/rootfs/dev 
+umount -l /mnt/volumio/rootfs/proc 
+umount -l /mnt/volumio/rootfs/sys 
+
+echo "==> cuboxi device installed"  
+
+#echo "Removing temporary platform files"
+#echo "(you can keep it safely as long as you're sure of no changes)"
+#sudo rm -r platforms-cuboxi
 sync
-  
-ls -al /mnt/volumio/
- 
-sudo umount /mnt/volumio/
- 
-echo
-echo 'umount'
-echo
+
+echo "Preparing rootfs base for SquashFS"
+
+if [ -d /mnt/squash ]; then
+	echo "Volumio SquashFS Temp Dir Exists - Cleaning it"
+	rm -rf /mnt/squash/*
+else
+	echo "Creating Volumio SquashFS Temp Dir"
+	sudo mkdir /mnt/squash
+fi
+
+echo "Copying Volumio rootfs to Temp Dir"
+cp -rp /mnt/volumio/rootfs/* /mnt/squash/
+
+echo "Removing the Kernel"
+rm -rf /mnt/squash/boot/*
+
+echo "Creating SquashFS, removing any previous one"
+rm -r Volumio.sqsh
+mksquashfs /mnt/squash/* Volumio.sqsh
+
+echo "Squash filesystem created"
+echo "Cleaning squash environment"
+rm -rf /mnt/squash
+
+#copy the squash image inside the boot partition
+cp Volumio.sqsh /mnt/volumio/images/volumio_current.sqsh
+sync
+echo "Unmounting Temp Devices"
+sudo umount -l /mnt/volumio/images
+sudo umount -l /mnt/volumio/rootfs/boot
+
+echo "Cleaning build environment"
+rm -rf /mnt/volumio /mnt/boot
+
+sudo dmsetup remove_all
 sudo losetup -d ${LOOP_DEV}
+sync

--- a/scripts/initramfs/init
+++ b/scripts/initramfs/init
@@ -17,6 +17,13 @@ mknod /dev/console c 5 1
 
 mdev -s
 
+#Hardware specific adaptions
+
+HWDEVICE="$(cat /proc/cpuinfo | grep Hardware | awk '{print $4}' )"
+if [ $HWDEVICE == i.MX6 ]; then
+   exec >/dev/kmsg 2>&1 </dev/console
+fi
+
 HWDEVICE="$(cat /proc/cpuinfo | grep Hardware | awk '{print $3}' )"
 
 #redirect console to kernel messages for Odroid
@@ -31,6 +38,8 @@ echo "Booting Volumio for" $HWDEVICE
 echo "	This script mounts rootfs RO with an overlay RW layer."
 
 # Do your stuff here.
+
+exec >/dev/kmsg 2>&1 </dev/console
 
 if [ $OVERLAY == WITHWRKDIR ]; then
    # For overlayfs version V22 or higher (modulename 'overlay')

--- a/scripts/initramfs/init-x86
+++ b/scripts/initramfs/init-x86
@@ -67,7 +67,8 @@ mknod /dev/tty c 5 0
 echo "Now probing usb  and pci storage..."
 modprobe usb_storage
 modprobe sd_mod
-modprobe ata_piix
+modprobe pata_sis
+
 
 echo "Waiting for storage devices to become ready"
 sleep 5

--- a/scripts/initramfs/init-x86
+++ b/scripts/initramfs/init-x86
@@ -307,6 +307,19 @@ mount --move /mnt/imgpart /mnt/ext/union/imgpart
 
 chmod -R 777 /mnt/ext/union/imgpart
 
+# Step 9: The UUID of the bootpartition could possibly not match the one used in fstab.
+#         This is the case when an new version of the squash file has been created.
+#         This step fixes that 
+# ============================================================================================
+UUID_BOOT=$(blkid -s UUID -o value ${BOOTPART})
+echo "Editing fstab to use UUID=<correct uuid of bootpartition>"
+if [ -e "/mnt/ext/union/etc/fstab.prev" ]; then
+  rm /mnt/ext/union/etc/fstab.prev
+fi
+mv /mnt/ext/union/etc/fstab /mnt/ext/union/etc/fstab.prev
+cp /mnt/ext/union/etc/fstab.tmpl /mnt/ext/union/etc/fstab
+sed -i "s/%%BOOTPART%%/UUID=${UUID_BOOT}/g" /mnt/ext/union/etc/fstab
+
 echo ${VOLUMIO_VERSION}
 echo "Finishing initramfs, switching rootfs and starting the boot process..."
 umount /proc

--- a/scripts/x86.sh
+++ b/scripts/x86.sh
@@ -99,7 +99,11 @@ mkdir -p /mnt/volumio/rootfs/boot/efi/EFI/debian
 mkdir -p /mnt/volumio/rootfs/boot/efi/BOOT/
 modprobe efivarfs
 
-echo "LOOP_DEV=${LOOP_DEV}
+UUID_BOOT=$(blkid -s UUID -o value ${BOOT_PART})
+UUID_IMG=$(blkid -s UUID -o value ${IMG_PART})
+echo "UUID_BOOT=${UUID_BOOT}
+UUID_IMG=${UUID_IMG}
+LOOP_DEV=${LOOP_DEV}
 BOOT_PART=${BOOT_PART}
 " >> /mnt/volumio/rootfs/init.sh
 chmod +x /mnt/volumio/rootfs/init.sh
@@ -107,6 +111,7 @@ chmod +x /mnt/volumio/rootfs/init.sh
 chroot /mnt/volumio/rootfs /bin/bash -x <<'EOF'
 /x86config.sh
 EOF
+
 rm /mnt/volumio/rootfs/init.sh /mnt/volumio/rootfs/linux-image-*.deb /mnt/volumio/rootfs/linux-firmware-*.deb
 rm /mnt/volumio/rootfs/root/init /mnt/volumio/rootfs/x86config.sh  
 sync

--- a/scripts/x86config.sh
+++ b/scripts/x86config.sh
@@ -153,6 +153,7 @@ echo "hid" >> /etc/initramfs-tools/modules
 echo "nls_cp437" >> /etc/initramfs-tools/modules
 echo "nls_utf8" >> /etc/initramfs-tools/modules
 echo "vfat" >> /etc/initramfs-tools/modules
+echo "pata_sis" >> /etc/initramfs-tools/modules
 
 echo "  Copying volumio initramfs updater"
 cd /root/

--- a/scripts/x86config.sh
+++ b/scripts/x86config.sh
@@ -34,7 +34,7 @@ echo "DEFAULT volumio
 LABEL volumio
   SAY Legacy Boot Volumio Audiophile Music Player (default)
   LINUX ${KRNL}
-  APPEND ro imgpart=LABEL=volumioimg bootpart=LABEL=volumioboot imgfile=volumio_current.sqsh quiet splash ${DEBUG}
+  APPEND ro imgpart=UUID=${UUID_IMG} bootpart=UUID=${UUID_BOOT} imgfile=volumio_current.sqsh quiet splash ${DEBUG}
   INITRD volumio.initrd
 " > /boot/syslinux.cfg
 
@@ -61,8 +61,8 @@ chmod +w boot/grub/grub.cfg
 
 echo "  Inserting root and boot partition label (building the boot cmdline used in initramfs)"
 # Opting for finding partitions by-LABEL
-sed -i "s/root=imgpart=%%IMGPART%%/imgpart=LABEL=volumioimg/g" /boot/grub/grub.cfg
-sed -i "s/bootpart=%%BOOTPART%%/bootpart=LABEL=volumioboot/g" /boot/grub/grub.cfg
+sed -i "s/root=imgpart=%%IMGPART%%/imgpart=UUID=${UUID_IMG}/g" /boot/grub/grub.cfg
+sed -i "s/bootpart=%%BOOTPART%%/bootpart=UUID=${UUID_BOOT}/g" /boot/grub/grub.cfg
 
 echo "  Prevent cgmanager starting during install (causing problems)" 
 cat > /usr/sbin/policy-rc.d << EOF
@@ -93,8 +93,10 @@ rm -f /var/lib/apt/lists/*archive*
 apt-get clean
 rm /usr/sbin/policy-rc.d
 
-echo "Editing fstab to use LABEL"
-sed -i "s/%%BOOTPART%%/LABEL=volumioboot/g" /etc/fstab
+echo "Copying fstab as a template to be used in initrd"
+cp /etc/fstab /etc/fstab.tmpl
+echo "Editing fstab to use UUID=<uuid of boot partition>"
+sed -i "s/%%BOOTPART%%/UUID=${UUID_BOOT}/g" /etc/fstab
 
 echo "Setting up in kiosk-mode"
 echo "  Creating chromium kiosk start script"


### PR DESCRIPTION
x86: this will allow you to boot a different build from usb after you cloned the original to the pc's hdd. However, after you cloned and you try to boot the same build from usb, it will always take the pc's hdd. Which is ok in most cases. The only real way of solving it, would be to make either the uuid or label unique on first boot or after an ota update and update syslinux config, grub config and fstab. The ota update would need a flag file, as would a new build.
For the time being, it will work. 