### PR TITLE
Generate SSH host keys on first start

### DIFF
--- a/scripts/volumioconfig.sh
+++ b/scripts/volumioconfig.sh
@@ -334,6 +334,9 @@ echo "Setting Mpd to SystemD instead of Init"
 update-rc.d mpd remove
 systemctl enable mpd.service
 
+echo "Removing default SSH host keys"
+# These should be created on first boot to ensure they are unique on each system
+rm -v /etc/ssh/ssh_host_*
 
 #####################
 #Audio Optimizations#-----------------------------------------

--- a/volumio/bin/firststart.sh
+++ b/volumio/bin/firststart.sh
@@ -5,6 +5,9 @@ echo "Volumio first start configuration script"
 echo "configuring unconfigured packages"
 dpkg --configure --pending
 
+echo "Generating SSH host keys"
+dpkg-reconfigure openssh-server
+
 echo "Installing winbind, its done here because else it will freeze networking"
 
 mkdir /var/log/samba


### PR DESCRIPTION
The host keys should not be reused between multiple devices.
This change ensures that each Volumio device have unique host keys.

If you know of a better way to do this please let me know and I change the pull request.

I have tested the change on a Raspberry Pi 3.