### PR TITLE
Install a minimal set of locales

### DIFF
--- a/recipes/arm.conf
+++ b/recipes/arm.conf
@@ -24,7 +24,7 @@ keyring=debian-archive-keyring
 suite=jessie
 
 [Utils]
-packages=nano psmisc ethtool curl ca-certificates ntp git-core parted wget avahi-daemon avahi-discover libnss-mdns zsync udisks udisks-glue policykit-1 less fake-hwclock usbutils
+packages=nano psmisc ethtool curl ca-certificates ntp git-core parted wget avahi-daemon avahi-discover libnss-mdns zsync udisks udisks-glue policykit-1 less fake-hwclock usbutils locales localepurge
 source=http://archive.raspbian.org/raspbian
 keyring=debian-archive-keyring
 suite=jessie

--- a/recipes/arm64.conf
+++ b/recipes/arm64.conf
@@ -24,7 +24,7 @@ keyring=debian-archive-keyring
 suite=jessie
 
 [Utils]
-packages=nano psmisc ethtool curl ca-certificates ntp git-core parted wget avahi-daemon avahi-discover libnss-mdns zsync udisks udisks-glue policykit-1
+packages=nano psmisc ethtool curl ca-certificates ntp git-core parted wget avahi-daemon avahi-discover libnss-mdns zsync udisks udisks-glue policykit-1 locales localepurge
 source=http://ftp.ch.debian.org/debian
 keyring=debian-archive-keyring
 suite=jessie

--- a/recipes/x86.conf
+++ b/recipes/x86.conf
@@ -31,7 +31,7 @@ keyring=debian-archive-keyring
 suite=jessie
 
 [Utils]
-packages=nano psmisc git wget ethtool curl ca-certificates ntp rpl avahi-daemon avahi-discover libnss-mdns zsync git-core binutils ca-certificates curl busybox parted udisks udisks-glue policykit-1 less usbutils gdisk
+packages=nano psmisc git wget ethtool curl ca-certificates ntp rpl avahi-daemon avahi-discover libnss-mdns zsync git-core binutils ca-certificates curl busybox parted udisks udisks-glue policykit-1 less usbutils gdisk locales localepurge
 source=http://httpredir.debian.org/debian
 keyring=debian-archive-keyring
 suite=jessie

--- a/scripts/volumioconfig.sh
+++ b/scripts/volumioconfig.sh
@@ -7,6 +7,27 @@ export LC_ALL=C LANGUAGE=C LANG=C
 /var/lib/dpkg/info/dash.preinst install
 dpkg --configure -a
 
+# Reduce locales to just one beyond C.UTF-8
+echo "Existing locales:"
+locale -a
+echo "Generating required locales:"
+[ -f /etc/locale.gen ] || touch -m /etc/locale.gen
+echo "en_US.UTF-8 UTF-8" >> /etc/locale.gen
+locale-gen
+echo "Removing unused locales"
+echo "en_US.UTF-8" >> /etc/locale.nopurge
+# To remove existing locale data we must turn off the dpkg hook
+sed -i -e 's/^USE_DPKG/#USE_DPKG/' /etc/locale.nopurge
+# Ensure that the package knows it has been configured
+sed -i -e 's/^NEEDSCONFIGFIRST/#NEEDSCONFIGFIRST/' /etc/locale.nopurge
+dpkg-reconfigure localepurge -f noninteractive
+localepurge
+# Turn dpkg feature back on, it will handle further locale-cleaning
+sed -i -e 's/^#USE_DPKG/USE_DPKG/' /etc/locale.nopurge
+dpkg-reconfigure localepurge -f noninteractive
+echo "Final locale list"
+locale -a
+echo ""
 
 #Adding Main user Volumio
 echo "Adding Volumio User"


### PR DESCRIPTION
It's useful to have some locales, but the full set can cost as much as 60-100MB
of disk space. Use localepurge to strip this back to a minimal set (enough to
keep Perl happy) at a cost of around 3MB.

Tested using ```-b arm -d pi ``` and ```-b x86 -d sparky``` . I did not test-boot the final images, that would probably worth doing before merging this.

Closes: volumio/Volumio2#306