### PR TITLE
add driver=nl80211 in base hostapd.conf

### DIFF
--- a/scripts/volumioconfig.sh
+++ b/scripts/volumioconfig.sh
@@ -407,6 +407,7 @@ echo "Configuring hostapd"
 echo "interface=wlan0
 ssid=Volumio
 channel=4
+driver=nl80211
 hw_mode=g
 auth_algs=1
 wpa=2


### PR DESCRIPTION
this driver helps support WPA2 authentication with most wifi chipsets (except Edimax which is treated separately)