### PR TITLE
Use Google DNS as fallback only

### DIFF
--- a/scripts/volumioconfig.sh
+++ b/scripts/volumioconfig.sh
@@ -420,10 +420,10 @@ echo "Hostapd conf files"
 cp /etc/hostapd/hostapd.conf /etc/hostapd/hostapd.tmpl
 chmod -R 777 /etc/hostapd
 
-echo "Setting default DNS with Google's DNS"
+echo "Setting fallback DNS with Google's DNS"
 echo "# Google nameservers
 nameserver 8.8.8.8
-nameserver 8.8.4.4" >> /etc/resolv.conf.head
+nameserver 8.8.4.4" >> /etc/resolv.conf.tail
 
 echo "Removing Avahi Service for UDISK-SSH"
 rm /etc/avahi/services/udisks.service


### PR DESCRIPTION
Current setup sets Google's DNS as defaults.
This can raise privacy concerns for some users (yes Google does track usage), and prevents addressing local resources (NAS, others) with local DNS.
Proposal is to let resolv.conf use DHCP server provided DNS, and append Google ones at the end, in case initial ones fail.