### PR TITLE
Logdirs2

### DIFF
--- a/scripts/bbbconfig.sh
+++ b/scripts/bbbconfig.sh
@@ -9,7 +9,7 @@ echo "# bbb fstab" > /etc/fstab
 echo "" >> /etc/fstab
 echo "proc            /proc           proc    defaults        0       0
 /dev/mmcblk0p1  /boot           vfat    defaults,utf8,user,rw,umask=111,dmask=000        0       1
-tmpfs   /var/log                tmpfs   size=20M,nodev,uid=1000,mode=0777,gid=4, 0 0
+tmpfs   /var/log                tmpfs   size=20M,nodev 0 0
 tmpfs   /var/spool/cups         tmpfs   defaults,noatime,mode=0755 0 0
 tmpfs   /var/spool/cups/tmp     tmpfs   defaults,noatime,mode=0755 0 0
 tmpfs   /tmp                    tmpfs   defaults,noatime,mode=0755 0 0

--- a/scripts/bpim2uconfig.sh
+++ b/scripts/bpim2uconfig.sh
@@ -9,7 +9,7 @@ echo "# Odroid C2 fstab" > /etc/fstab
 echo "" >> /etc/fstab
 echo "proc            /proc           proc    defaults        0       0
 /dev/mmcblk0p1  /boot           vfat    defaults,utf8,user,rw,umask=111,dmask=000        0       1
-tmpfs   /var/log                tmpfs   size=20M,nodev,uid=1000,mode=0777,gid=4, 0 0
+tmpfs   /var/log                tmpfs   size=20M,nodev 0 0
 tmpfs   /var/spool/cups         tmpfs   defaults,noatime,mode=0755 0 0
 tmpfs   /var/spool/cups/tmp     tmpfs   defaults,noatime,mode=0755 0 0
 tmpfs   /tmp                    tmpfs   defaults,noatime,mode=0755 0 0

--- a/scripts/bpiproconfig.sh
+++ b/scripts/bpiproconfig.sh
@@ -9,7 +9,7 @@ echo "# BPI-PRO fstab" > /etc/fstab
 echo "" >> /etc/fstab
 echo "proc            /proc           proc    defaults        0       0
 /dev/mmcblk0p1  /boot           vfat    defaults,utf8,user,rw,umask=111,dmask=000        0       1
-tmpfs   /var/log                tmpfs   size=20M,nodev,uid=1000,mode=0777,gid=4, 0 0 
+tmpfs   /var/log                tmpfs   size=20M,nodev 0 0 
 tmpfs   /var/spool/cups         tmpfs   defaults,noatime,mode=0755 0 0
 tmpfs   /var/spool/cups/tmp     tmpfs   defaults,noatime,mode=0755 0 0
 tmpfs   /tmp                    tmpfs   defaults,noatime,mode=0755 0 0

--- a/scripts/bpiproconfig.sh
+++ b/scripts/bpiproconfig.sh
@@ -9,7 +9,7 @@ echo "# BPI-PRO fstab" > /etc/fstab
 echo "" >> /etc/fstab
 echo "proc            /proc           proc    defaults        0       0
 /dev/mmcblk0p1  /boot           vfat    defaults,utf8,user,rw,umask=111,dmask=000        0       1
-tmpfs   /var/log                tmpfs   size=20M,nodev 0 0 
+tmpfs   /var/log                tmpfs   size=20M,nodev 0 0
 tmpfs   /var/spool/cups         tmpfs   defaults,noatime,mode=0755 0 0
 tmpfs   /var/spool/cups/tmp     tmpfs   defaults,noatime,mode=0755 0 0
 tmpfs   /tmp                    tmpfs   defaults,noatime,mode=0755 0 0

--- a/scripts/configure.sh
+++ b/scripts/configure.sh
@@ -86,6 +86,8 @@ cp -rp volumio/etc/dhcpcd.conf build/$BUILD/root/etc/
 #wifi pre script
 cp volumio/bin/wifistart.sh build/$BUILD/root/bin/wifistart.sh
 chmod a+x build/$BUILD/root/bin/wifistart.sh
+#Log setup
+cp volumio/bin/logdirs.sh build/$BUILD/root/bin/logdirs.sh
 echo 'Done Copying Custom Volumio System Files'
 
 echo "Stripping binaries and libraries to save space"

--- a/scripts/cuboxiconfig.sh
+++ b/scripts/cuboxiconfig.sh
@@ -9,7 +9,7 @@ echo "# cuboxi fstab" > /etc/fstab
 echo "" >> /etc/fstab
 echo "proc            /proc           proc    defaults        0       0
 /dev/mmcblk0p1  /boot           vfat    defaults,utf8,user,rw,umask=111,dmask=000        0       1
-tmpfs   /var/log                tmpfs   size=20M,nodev,uid=1000,mode=0777,gid=4, 0 0
+tmpfs   /var/log                tmpfs   size=20M,nodev 0 0
 tmpfs   /var/spool/cups         tmpfs   defaults,noatime,mode=0755 0 0
 tmpfs   /var/spool/cups/tmp     tmpfs   defaults,noatime,mode=0755 0 0
 tmpfs   /tmp                    tmpfs   defaults,noatime,mode=0755 0 0

--- a/scripts/odroidc1config.sh
+++ b/scripts/odroidc1config.sh
@@ -9,7 +9,7 @@ echo "# Odroid C1 fstab" > /etc/fstab
 echo "" >> /etc/fstab
 echo "proc            /proc           proc    defaults        0       0
 /dev/mmcblk0p1  /boot           vfat    defaults,utf8,user,rw,umask=111,dmask=000        0       1
-tmpfs   /var/log                tmpfs   size=20M,nodev,uid=1000,mode=0777,gid=4, 0 0
+tmpfs   /var/log                tmpfs   size=20M,nodev 0 0
 tmpfs   /var/spool/cups         tmpfs   defaults,noatime,mode=0755 0 0
 tmpfs   /var/spool/cups/tmp     tmpfs   defaults,noatime,mode=0755 0 0
 tmpfs   /tmp                    tmpfs   defaults,noatime,mode=0755 0 0

--- a/scripts/odroidc2config.sh
+++ b/scripts/odroidc2config.sh
@@ -9,7 +9,7 @@ echo "# Odroid C2 fstab" > /etc/fstab
 echo "" >> /etc/fstab
 echo "proc            /proc           proc    defaults        0       0
 /dev/mmcblk0p1  /boot           vfat    defaults,utf8,user,rw,umask=111,dmask=000        0       1
-tmpfs   /var/log                tmpfs   size=20M,nodev,uid=1000,mode=0777,gid=4, 0 0
+tmpfs   /var/log                tmpfs   size=20M,nodev 0 0
 tmpfs   /var/spool/cups         tmpfs   defaults,noatime,mode=0755 0 0
 tmpfs   /var/spool/cups/tmp     tmpfs   defaults,noatime,mode=0755 0 0
 tmpfs   /tmp                    tmpfs   defaults,noatime,mode=0755 0 0

--- a/scripts/odroidx2config.sh
+++ b/scripts/odroidx2config.sh
@@ -12,7 +12,7 @@ echo "# OdroidXU fstab" > /etc/fstab
 echo "" >> /etc/fstab
 echo "proc            /proc           proc    defaults        0       0
 /dev/mmcblk0p1  /boot           vfat    defaults,utf8,user,rw,umask=111,dmask=000        0       1
-tmpfs   /var/log                tmpfs   size=20M,nodev,uid=1000,mode=0777,gid=4, 0 0
+tmpfs   /var/log                tmpfs   size=20M,nodev 0 0
 tmpfs   /var/spool/cups         tmpfs   defaults,noatime,mode=0755 0 0
 tmpfs   /var/spool/cups/tmp     tmpfs   defaults,noatime,mode=0755 0 0
 tmpfs   /tmp                    tmpfs   defaults,noatime,mode=0755 0 0

--- a/scripts/odroidxu4config.sh
+++ b/scripts/odroidxu4config.sh
@@ -12,7 +12,7 @@ echo "# OdroidXU fstab" > /etc/fstab
 echo "" >> /etc/fstab
 echo "proc            /proc           proc    defaults        0       0
 /dev/mmcblk0p1  /boot           vfat    defaults,utf8,user,rw,umask=111,dmask=000        0       1
-tmpfs   /var/log                tmpfs   size=20M,nodev,uid=1000,mode=0777,gid=4, 0 0
+tmpfs   /var/log                tmpfs   size=20M,nodev 0 0
 tmpfs   /var/spool/cups         tmpfs   defaults,noatime,mode=0755 0 0
 tmpfs   /var/spool/cups/tmp     tmpfs   defaults,noatime,mode=0755 0 0
 tmpfs   /tmp                    tmpfs   defaults,noatime,mode=0755 0 0

--- a/scripts/pine64config.sh
+++ b/scripts/pine64config.sh
@@ -9,7 +9,7 @@ echo "# Odroid C2 fstab" > /etc/fstab
 echo "" >> /etc/fstab
 echo "proc            /proc           proc    defaults        0       0
 /dev/mmcblk0p1  /boot           vfat    defaults,utf8,user,rw,umask=111,dmask=000        0       1
-tmpfs   /var/log                tmpfs   size=20M,nodev,uid=1000,mode=0777,gid=4, 0 0
+tmpfs   /var/log                tmpfs   size=20M,nodev 0 0
 tmpfs   /var/spool/cups         tmpfs   defaults,noatime,mode=0755 0 0
 tmpfs   /var/spool/cups/tmp     tmpfs   defaults,noatime,mode=0755 0 0
 tmpfs   /tmp                    tmpfs   defaults,noatime,mode=0755 0 0

--- a/scripts/raspberryconfig.sh
+++ b/scripts/raspberryconfig.sh
@@ -17,7 +17,7 @@ echo "Creating Fstab File"
 touch /etc/fstab
 echo "proc            /proc           proc    defaults        0       0
 /dev/mmcblk0p1  /boot           vfat    defaults,utf8,user,rw,umask=111,dmask=000        0       1
-tmpfs   /var/log                tmpfs   size=20M,nodev,uid=1000,mode=0777,gid=4, 0 0
+tmpfs   /var/log                tmpfs   size=20M,nodev 0 0
 tmpfs   /var/spool/cups         tmpfs   defaults,noatime,mode=0755 0 0
 tmpfs   /var/spool/cups/tmp     tmpfs   defaults,noatime,mode=0755 0 0
 tmpfs   /tmp                    tmpfs   defaults,noatime,mode=0755 0 0

--- a/scripts/sparkyconfig.sh
+++ b/scripts/sparkyconfig.sh
@@ -9,7 +9,7 @@ echo "# sparky fstab" > /etc/fstab
 echo "" >> /etc/fstab
 echo "proc            /proc           proc    defaults        0       0
 /dev/mmcblk0p1  /boot           vfat    defaults,utf8,user,rw,umask=111,dmask=000        0       1
-tmpfs   /var/log                tmpfs   size=20M,nodev,uid=1000,mode=0777,gid=4, 0 0
+tmpfs   /var/log                tmpfs   size=20M,nodev 0 0
 tmpfs   /var/spool/cups         tmpfs   defaults,noatime,mode=0755 0 0
 tmpfs   /var/spool/cups/tmp     tmpfs   defaults,noatime,mode=0755 0 0
 tmpfs   /tmp                    tmpfs   defaults,noatime,mode=0755 0 0

--- a/scripts/udooneoconfig.sh
+++ b/scripts/udooneoconfig.sh
@@ -19,7 +19,7 @@ echo "proc            /proc           proc    defaults        0       0
 /dev/mmcblk0p1  /boot           vfat    defaults,utf8,user,rw,umask=111,dmask=000,noauto,nofail        0       1
 /dev/mmcblk0p2  /               ext4    defaults,noatime               0  0
 /dev/mmcblk0p3  /data           ext4    defaults,noatime,noauto,nofail               0  0
-tmpfs   /var/log                tmpfs   size=20M,nodev 0 0 
+tmpfs   /var/log                tmpfs   size=20M,nodev 0 0
 tmpfs   /var/spool/cups         tmpfs   defaults,noatime,mode=0755 0 0
 tmpfs   /var/spool/cups/tmp     tmpfs   defaults,noatime,mode=0755 0 0
 tmpfs   /tmp                    tmpfs   defaults,noatime,mode=0755 0 0

--- a/scripts/udooneoconfig.sh
+++ b/scripts/udooneoconfig.sh
@@ -19,7 +19,7 @@ echo "proc            /proc           proc    defaults        0       0
 /dev/mmcblk0p1  /boot           vfat    defaults,utf8,user,rw,umask=111,dmask=000,noauto,nofail        0       1
 /dev/mmcblk0p2  /               ext4    defaults,noatime               0  0
 /dev/mmcblk0p3  /data           ext4    defaults,noatime,noauto,nofail               0  0
-tmpfs   /var/log                tmpfs   size=20M,nodev,uid=1000,mode=0777,gid=4, 0 0 
+tmpfs   /var/log                tmpfs   size=20M,nodev 0 0 
 tmpfs   /var/spool/cups         tmpfs   defaults,noatime,mode=0755 0 0
 tmpfs   /var/spool/cups/tmp     tmpfs   defaults,noatime,mode=0755 0 0
 tmpfs   /tmp                    tmpfs   defaults,noatime,mode=0755 0 0

--- a/scripts/volumioconfig.sh
+++ b/scripts/volumioconfig.sh
@@ -418,3 +418,16 @@ chmod 775 "$d"
 find /var/log -maxdepth 1 -type d | egrep -v 'log$'| \
     xargs tar cf /etc/logdirs.tar --no-recursion
 
+# For long-running instances, log rotation will be needed
+echo '
+/var/log/volumio/*.log
+{
+    rotate 1
+    daily
+    notifempty
+    missingok
+    compress
+    create 0644 volumio volumio
+}
+' > /etc/logrotate.d/volumio
+

--- a/scripts/volumioconfig.sh
+++ b/scripts/volumioconfig.sh
@@ -337,6 +337,9 @@ ln -s /lib/systemd/system/firststart.service /etc/systemd/system/multi-user.targ
 echo "Adding Dynamic Swap Service"
 ln -s /lib/systemd/system/dynamicswap.service /etc/systemd/system/multi-user.target.wants/dynamicswap.service
 
+echo "Adding log subdirectories setup to Startup"
+ln -s /lib/systemd/system/logdirs.service /etc/systemd/system/multi-user.target.wants/logdirs.service
+
 echo "Setting Mpd to SystemD instead of Init"
 update-rc.d mpd remove
 systemctl enable mpd.service

--- a/scripts/volumioconfig.sh
+++ b/scripts/volumioconfig.sh
@@ -408,3 +408,13 @@ mkdir /var/lib/dhcpcd5
 touch /var/lib/dhcpcd5/dhcpcd-wlan0.lease
 touch /var/lib/dhcpcd5/dhcpcd-eth0.lease
 chmod -R 777 /var/lib/dhcpcd5
+
+echo "Fine-tuning logging setup"
+d=/var/log/volumio
+[ -d "$d" ] || mkdir "$d"
+chown volumio:volumio "$d"
+chmod 775 "$d"
+# This tar file will be unpacked by logdirs.service
+find /var/log -maxdepth 1 -type d | egrep -v 'log$'| \
+    xargs tar cf /etc/logdirs.tar --no-recursion
+

--- a/volumio/bin/firststart.sh
+++ b/volumio/bin/firststart.sh
@@ -16,7 +16,7 @@ echo "configuring unconfigured packages"
 dpkg --configure --pending
 
 echo "Creating /var/log/samba folder"
-mkdir /var/log/samba
+[ -d /var/log/samba ] || mkdir /var/log/samba
 
 echo "Removing default SSH host keys"
 # These should be created on first boot to ensure they are unique on each system

--- a/volumio/bin/logdirs.sh
+++ b/volumio/bin/logdirs.sh
@@ -1,0 +1,19 @@
+#!/bin/sh
+
+TAR=/etc/logdirs.tar
+
+echo "Preparing /var/log directory tree"
+ls "/var/log" 1>/dev/null || exit 1
+if [ ! -f "$TAR" ]; then
+     echo "Can't find '$TAR', skipping"
+     exit 0
+fi
+
+cd /
+tar xf "$TAR"
+
+unset TAR
+
+echo "Finalizing"
+sync
+

--- a/volumio/lib/systemd/system/logdirs.service
+++ b/volumio/lib/systemd/system/logdirs.service
@@ -1,0 +1,13 @@
+[Unit]
+Description=Prepare subdirectories on tmpfs logging filesystem
+Requires=local-fs.target
+After=var-log.mount
+
+[Service]
+Type=oneshot
+ExecStart=/bin/logdirs.sh
+TimeoutSec=30
+
+[Install]
+WantedBy=multi-user.target
+


### PR DESCRIPTION
Issue #93 reported that /var/log was being created as a tmpfs on top of the SD card and that it lacked some subdirectories that the build system had placed there, e.g. /var/log/samba.
This series of changes ensures that the subdirs created during image build are reproduced on the tmpfs version of /var/log, once that filesystem is mounted at runtime.

This has been tested on RPi2 and works as expected. This PR replaces #99.

Merging this will require moving /var/log/volumio.log to /var/log/volumio/volumio.log (in app/index.js) and /var/log/albumart.log to /var/log/volumio/albumart.log (in app/plugins/miscellanea/albumart/albumart.js).