### PR TITLE
boot mgr fixed

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -248,8 +248,10 @@ case $DEVICE in
       sh scripts/bpim2uimage.sh -v $VERSION -p $PATCH;
       ;;
   bpipro) echo 'Writing Banana PI PRO Image File'
-      check_os_release "armV7" $VERSION $DEVICE
-      sh scripts/bpiproimage.sh.sh -v $VERSION -p $PATCH;
+      # check_os_release "armV7" $VERSION $DEVICE
+      # sh scripts/bpiproimage.sh.sh -v $VERSION -p $PATCH;
+      check_os_release "arm" $VERSION $DEVICE
+      sh scripts/bpiproimage.sh -v $VERSION -p $PATCH;
       ;;    
   x86) echo 'Writing x86 Image File'
       check_os_release "x86" $VERSION $DEVICE

--- a/scripts/bpiproconfig.sh
+++ b/scripts/bpiproconfig.sh
@@ -5,7 +5,7 @@ PATCH=$(cat /patch)
 # This script will be run in chroot under qemu.
 
 echo "Creating \"fstab\""
-echo "# BPI-PRO fstab" > /etc/fstab
+echo "# Odroid C2 fstab" > /etc/fstab
 echo "" >> /etc/fstab
 echo "proc            /proc           proc    defaults        0       0
 /dev/mmcblk0p1  /boot           vfat    defaults,utf8,user,rw,umask=111,dmask=000        0       1
@@ -43,6 +43,7 @@ apt-get clean
 rm /usr/sbin/policy-rc.d
 
 echo "Adding custom modules overlayfs, squashfs and nls_cp437"
+echo "overlay" >> /etc/initramfs-tools/modules
 echo "overlayfs" >> /etc/initramfs-tools/modules
 echo "squashfs" >> /etc/initramfs-tools/modules
 echo "nls_cp437" >> /etc/initramfs-tools/modules
@@ -83,5 +84,5 @@ mkinitramfs-custom.sh -o /tmp/initramfs-tmp
 echo "Creating uInitrd from 'volumio.initrd'"
 mkimage -A arm -O linux -T ramdisk -C none -a 0 -e 0 -n uInitrd -d /boot/volumio.initrd /boot/uInitrd
 echo "Cleaning up"
-rm /boot/volumio.initrd
+# rm /boot/volumio.initrd
 

--- a/scripts/bpiproconfig.sh
+++ b/scripts/bpiproconfig.sh
@@ -5,7 +5,7 @@ PATCH=$(cat /patch)
 # This script will be run in chroot under qemu.
 
 echo "Creating \"fstab\""
-echo "# Odroid C2 fstab" > /etc/fstab
+echo "# BPI-PRO fstab" > /etc/fstab
 echo "" >> /etc/fstab
 echo "proc            /proc           proc    defaults        0       0
 /dev/mmcblk0p1  /boot           vfat    defaults,utf8,user,rw,umask=111,dmask=000        0       1
@@ -43,7 +43,6 @@ apt-get clean
 rm /usr/sbin/policy-rc.d
 
 echo "Adding custom modules overlayfs, squashfs and nls_cp437"
-echo "overlay" >> /etc/initramfs-tools/modules
 echo "overlayfs" >> /etc/initramfs-tools/modules
 echo "squashfs" >> /etc/initramfs-tools/modules
 echo "nls_cp437" >> /etc/initramfs-tools/modules

--- a/scripts/bpiproimage.sh
+++ b/scripts/bpiproimage.sh
@@ -1,7 +1,5 @@
 #!/bin/sh
-
-# Default build for Debian 32bit
-ARCH="armv7"
+set -x
 
 while getopts ":v:p:" opt; do
   case $opt in
@@ -18,26 +16,30 @@ done
 BUILDDATE=$(date -I)
 IMG_FILE="Volumio${VERSION}-${BUILDDATE}-bananapi-pro.img"
 
-if [ "$ARCH" = arm ]; then
-  DISTRO="Raspbian"
-else
-  DISTRO="Debian 32bit"
-fi
 
-echo "Creating Image File ${IMG_FILE} with $DISTRO rootfs" 
-dd if=/dev/zero of=${IMG_FILE} bs=1M count=1600
+echo "Creating Image File"
+echo "Image file: ${IMG_FILE}"
+dd if=/dev/zero of=${IMG_FILE} bs=1M count=1700
+# dd if=/home/chris/bananian-1604.img of=${IMG_FILE} bs=1M conv=sync
+# dd if=/home/chris/bootsec4 of=${IMG_FILE} seek=0 conv=notrunc
 
 echo "Creating Image Bed"
 LOOP_DEV=`sudo losetup -f --show ${IMG_FILE}`
 # Note: leave the first 20Mb free for the firmware
-parted -s "${LOOP_DEV}" mklabel msdos
-parted -s "${LOOP_DEV}" mkpart primary fat32 1 64
-parted -s "${LOOP_DEV}" mkpart primary ext3 65 1500
-parted -s "${LOOP_DEV}" mkpart primary ext3 1500 100%
-parted -s "${LOOP_DEV}" set 1 boot on
-parted -s "${LOOP_DEV}" print
-partprobe "${LOOP_DEV}"
-kpartx -s -a "${LOOP_DEV}"
+
+echo "Loop-Dev: ${LOOP_DEV}" 
+sudo parted -s "${LOOP_DEV}" print
+
+# exit 0
+
+sudo parted -s "${LOOP_DEV}" mklabel msdos
+sudo parted -s "${LOOP_DEV}" mkpart primary fat32 105 172
+sudo parted -s "${LOOP_DEV}" mkpart primary ext3 172 1650
+sudo parted -s "${LOOP_DEV}" mkpart primary ext3 1650 100%
+sudo parted -s "${LOOP_DEV}" set 1 boot on
+sudo parted -s "${LOOP_DEV}" print
+sudo partprobe "${LOOP_DEV}"
+sudo kpartx -s -a "${LOOP_DEV}"
 
 BOOT_PART=`echo /dev/mapper/"$( echo ${LOOP_DEV} | sed -e 's/.*\/\(\w*\)/\1/' )"p1`
 SYS_PART=`echo /dev/mapper/"$( echo ${LOOP_DEV} | sed -e 's/.*\/\(\w*\)/\1/' )"p2`
@@ -52,28 +54,33 @@ then
 fi
 
 echo "Creating boot and rootfs filesystems"
-mkfs -t vfat -n BOOT "${BOOT_PART}"
-mkfs -F -t ext4 -L volumio "${SYS_PART}"
-mkfs -F -t ext4 -L volumio_data "${DATA_PART}"
+sudo mkfs -t vfat -n BOOT "${BOOT_PART}"
+sudo mkfs -F -t ext4 -L volumio "${SYS_PART}"
+sudo mkfs -F -t ext4 -L volumio_data "${DATA_PART}"
 sync
 
-echo "Preparing for the banana bpi-m2u kernel/ platform files"
+## CM
+## exit 0
+
+echo "Preparing for the banana bpi-pro kernel/ platform files"
 if [ -d platform-banana ]
 then 
 	echo "Platform folder already exists - keeping it"
     # if you really want to re-clone from the repo, then delete the platform-banana folder
     # that will refresh all the bananapi platforms, see below
 else
+	mkdir platform-banana
 	echo "Clone bananapi pro files from repo"
-	git clone https://github.com/gkkpch/platform-banana.git platform-banana
+	git clone https://github.com/chrismade/platform-banana.git platform-banana
 	echo "Unpack the platform files"
-    cd platform-banana
-	tar xfJ bpi-pro.tar.xz
+    	cd platform-banana
+	# tar xfJ bpi-m2u.tar.xz
+	tar xvzf kernel_3_4_113_w_olfs.tgz
+echo "Copying the bootloader"
+sudo dd if=boot/u-boot-sunxi-with-spl.bin of=${LOOP_DEV} bs=1024 seek=8 
 	cd ..
 fi
 
-echo "Copying the bootloader"
-dd if=platform-banana/bpi-pro/uboot/u-boot-sunxi-with-spl.bin of=${LOOP_DEV} conv=notrunc bs=1k seek=8
 sync
 
 echo "Preparing for Volumio rootfs"
@@ -81,7 +88,7 @@ if [ -d /mnt ]
 then 
 	echo "/mount folder exist"
 else
-	mkdir /mnt
+	sudo mkdir /mnt
 fi
 if [ -d /mnt/volumio ]
 then 
@@ -94,22 +101,40 @@ fi
 
 echo "Creating mount point for the images partition"
 mkdir /mnt/volumio/images
-mount -t ext4 "${SYS_PART}" /mnt/volumio/images
-mkdir /mnt/volumio/rootfs
+sudo mount -t ext4 "${SYS_PART}" /mnt/volumio/images
+sudo mkdir /mnt/volumio/rootfs
 echo "Creating mount point for the boot partition"
-mkdir /mnt/volumio/rootfs/boot
-mount -t vfat "${BOOT_PART}" /mnt/volumio/rootfs/boot
+sudo mkdir /mnt/volumio/rootfs/boot
+sudo mount -t vfat "${BOOT_PART}" /mnt/volumio/rootfs/boot
+
+sudo mkdir /mnt/volumio/rootfs/proc
+sudo mkdir /mnt/volumio/rootfs/sys
+sudo mkdir /mnt/volumio/rootfs/root
 
 echo "Copying Volumio RootFs"
-cp -pdR build/arm/root/* /mnt/volumio/rootfs
-echo "Copying BPI-PRO boot files"
-cp platform-banana/bpi-pro/boot/uImage /mnt/volumio/rootfs/boot/
-cp platform-banana/bpi-pro/boot/config* /mnt/volumio/rootfs/boot/
-mkimage -C none -A arm -T script -d platform-banana/bpi-pro/boot/boot.cmd mnt/volumio/rootfs/boot/boot.scr
+sudo cp -pdR build/arm/root/* /mnt/volumio/rootfs
+echo "Copying BANANA-PI boot files"
+# mkdir -p /mnt/volumio/rootfs/boot/bananapi
+# mkdir -p /mnt/volumio/rootfs/boot/bananapi/bananapi
+# mkdir -p /mnt/volumio/rootfs/boot/bananapi/bananapi/linux
+# sudo cp platform-banana/bananapi/boot/uImage /mnt/volumio/rootfs/boot/bananapi/bananapi/linux
+# sudo cp platform-banana/bananapi/boot/uEnv.txt /mnt/volumio/rootfs/boot/bananapi/bananapi/linux
+# sudo cp platform-banana/bananapi/boot/Image.version /mnt/volumio/rootfs/boot/
+# sudo cp platform-banana/bananapi/boot/config* /mnt/volumio/rootfs/boot/
+cp /home/chris/bootp01/boot_rd.cmd /mnt/volumio/rootfs/boot/
+sudo cp platform-banana/bananapi/boot/zImage /mnt/volumio/rootfs/boot/zImage-next
 
-echo "Copying BPI-M2U modules and firmware"
-cp -pdR platform-banana/bpi-pro/lib/modules /mnt/volumio/rootfs/lib/
-cp -pdR platform-banana/bpi-pro/lib/firmware /mnt/volumio/rootfs/lib/
+echo "CM update boot partition"
+sudo cp -pdR platform-banana/bananapi/boot/* /mnt/volumio/rootfs/boot
+
+echo "Copying BPI-PRO modules and firmware"
+mkdir /mnt/volumio/rootfs/lib/
+sudo cp -pdR platform-banana/bananapi/lib/modules /mnt/volumio/rootfs/lib/
+sudo cp -pdR platform-banana/bananapi/lib/firmware /mnt/volumio/rootfs/lib/
+
+
+#TODO: bananapi's should be able to run generic debian
+#sed -i "s/Raspbian/Debian/g" /mnt/volumio/rootfs/etc/issue
 
 sync
 
@@ -130,6 +155,10 @@ su -
 /bpiproconfig.sh
 EOF
 
+echo "Moving uInitrd to where the kernel is"
+# sudo mv /mnt/volumio/rootfs/boot/uInitrd /mnt/volumio/rootfs/boot/bananapi/bananapi/linux/uInitrd
+cp /mnt/volumio/rootfs/boot/* /home/chris/bootsav0
+
 #cleanup
 rm /mnt/volumio/rootfs/bpiproconfig.sh /mnt/volumio/rootfs/root/init
 
@@ -145,7 +174,7 @@ echo "==> BPI-PRO device installed"
 
 #echo "Removing temporary platform files"
 #echo "(you can keep it safely as long as you're sure of no changes)"
-#rm -r platform-bananapi
+#sudo rm -r platform-bananapi
 sync
 
 echo "Preparing rootfs base for SquashFS"
@@ -155,7 +184,7 @@ if [ -d /mnt/squash ]; then
 	rm -rf /mnt/squash/*
 else
 	echo "Creating Volumio SquashFS Temp Dir"
-	mkdir /mnt/squash
+	sudo mkdir /mnt/squash
 fi
 
 echo "Copying Volumio rootfs to Temp Dir"
@@ -176,14 +205,14 @@ rm -rf /mnt/squash
 cp Volumio.sqsh /mnt/volumio/images/volumio_current.sqsh
 sync
 echo "Unmounting Temp Devices"
-umount -l /mnt/volumio/images
-umount -l /mnt/volumio/rootfs/boot
+sudo umount -l /mnt/volumio/images
+sudo umount -l /mnt/volumio/rootfs/boot
 
 echo "Cleaning build environment"
-rm -rf /mnt/volumio /mnt/boot
+# rm -rf /mnt/volumio /mnt/boot
 
-dmsetup remove_all
-losetup -d ${LOOP_DEV}
+sudo dmsetup remove_all
+sudo losetup -d ${LOOP_DEV}
 sync
 
 md5sum "$IMG_FILE" > "${IMG_FILE}.md5"

--- a/scripts/bpiproimage.sh
+++ b/scripts/bpiproimage.sh
@@ -1,5 +1,7 @@
 #!/bin/sh
-set -x
+
+# Default build for Debian 32bit
+ARCH="armv7"
 
 while getopts ":v:p:" opt; do
   case $opt in
@@ -16,30 +18,26 @@ done
 BUILDDATE=$(date -I)
 IMG_FILE="Volumio${VERSION}-${BUILDDATE}-bananapi-pro.img"
 
+if [ "$ARCH" = arm ]; then
+  DISTRO="Raspbian"
+else
+  DISTRO="Debian 32bit"
+fi
 
-echo "Creating Image File"
-echo "Image file: ${IMG_FILE}"
-dd if=/dev/zero of=${IMG_FILE} bs=1M count=1700
-# dd if=/home/chris/bananian-1604.img of=${IMG_FILE} bs=1M conv=sync
-# dd if=/home/chris/bootsec4 of=${IMG_FILE} seek=0 conv=notrunc
+echo "Creating Image File ${IMG_FILE} with $DISTRO rootfs" 
+dd if=/dev/zero of=${IMG_FILE} bs=1M count=1600
 
 echo "Creating Image Bed"
 LOOP_DEV=`sudo losetup -f --show ${IMG_FILE}`
 # Note: leave the first 20Mb free for the firmware
-
-echo "Loop-Dev: ${LOOP_DEV}" 
-sudo parted -s "${LOOP_DEV}" print
-
-# exit 0
-
-sudo parted -s "${LOOP_DEV}" mklabel msdos
-sudo parted -s "${LOOP_DEV}" mkpart primary fat32 105 172
-sudo parted -s "${LOOP_DEV}" mkpart primary ext3 172 1650
-sudo parted -s "${LOOP_DEV}" mkpart primary ext3 1650 100%
-sudo parted -s "${LOOP_DEV}" set 1 boot on
-sudo parted -s "${LOOP_DEV}" print
-sudo partprobe "${LOOP_DEV}"
-sudo kpartx -s -a "${LOOP_DEV}"
+parted -s "${LOOP_DEV}" mklabel msdos
+parted -s "${LOOP_DEV}" mkpart primary fat32 1 64
+parted -s "${LOOP_DEV}" mkpart primary ext3 65 1500
+parted -s "${LOOP_DEV}" mkpart primary ext3 1500 100%
+parted -s "${LOOP_DEV}" set 1 boot on
+parted -s "${LOOP_DEV}" print
+partprobe "${LOOP_DEV}"
+kpartx -s -a "${LOOP_DEV}"
 
 BOOT_PART=`echo /dev/mapper/"$( echo ${LOOP_DEV} | sed -e 's/.*\/\(\w*\)/\1/' )"p1`
 SYS_PART=`echo /dev/mapper/"$( echo ${LOOP_DEV} | sed -e 's/.*\/\(\w*\)/\1/' )"p2`
@@ -54,13 +52,10 @@ then
 fi
 
 echo "Creating boot and rootfs filesystems"
-sudo mkfs -t vfat -n BOOT "${BOOT_PART}"
-sudo mkfs -F -t ext4 -L volumio "${SYS_PART}"
-sudo mkfs -F -t ext4 -L volumio_data "${DATA_PART}"
+mkfs -t vfat -n BOOT "${BOOT_PART}"
+mkfs -F -t ext4 -L volumio "${SYS_PART}"
+mkfs -F -t ext4 -L volumio_data "${DATA_PART}"
 sync
-
-## CM
-## exit 0
 
 echo "Preparing for the banana bpi-pro kernel/ platform files"
 if [ -d platform-banana ]
@@ -69,18 +64,18 @@ then
     # if you really want to re-clone from the repo, then delete the platform-banana folder
     # that will refresh all the bananapi platforms, see below
 else
-	mkdir platform-banana
 	echo "Clone bananapi pro files from repo"
-	git clone https://github.com/chrismade/platform-banana.git platform-banana
+	git clone https://github.com/gkkpch/platform-banana.git platform-banana
 	echo "Unpack the platform files"
-    	cd platform-banana
-	# tar xfJ bpi-m2u.tar.xz
-	tar xvzf kernel_3_4_113_w_olfs.tgz
-echo "Copying the bootloader"
-sudo dd if=boot/u-boot-sunxi-with-spl.bin of=${LOOP_DEV} bs=1024 seek=8 
-	cd ..
+    cd platform-banana
+	tar xfJ bpi-pro.tar.xz
+	wget https://raw.githubusercontent.com/chrismade/platform-banana-pi/master/bootp01.tgz
+	tar xvzf bootp01.tgz
+    cd ..
 fi
 
+echo "Copying the bootloader"
+dd if=platform-banana/bpi-pro/uboot/u-boot-sunxi-with-spl.bin of=${LOOP_DEV} conv=notrunc bs=1k seek=8
 sync
 
 echo "Preparing for Volumio rootfs"
@@ -88,7 +83,7 @@ if [ -d /mnt ]
 then 
 	echo "/mount folder exist"
 else
-	sudo mkdir /mnt
+	mkdir /mnt
 fi
 if [ -d /mnt/volumio ]
 then 
@@ -101,40 +96,23 @@ fi
 
 echo "Creating mount point for the images partition"
 mkdir /mnt/volumio/images
-sudo mount -t ext4 "${SYS_PART}" /mnt/volumio/images
-sudo mkdir /mnt/volumio/rootfs
+mount -t ext4 "${SYS_PART}" /mnt/volumio/images
+mkdir /mnt/volumio/rootfs
 echo "Creating mount point for the boot partition"
-sudo mkdir /mnt/volumio/rootfs/boot
-sudo mount -t vfat "${BOOT_PART}" /mnt/volumio/rootfs/boot
-
-sudo mkdir /mnt/volumio/rootfs/proc
-sudo mkdir /mnt/volumio/rootfs/sys
-sudo mkdir /mnt/volumio/rootfs/root
+mkdir /mnt/volumio/rootfs/boot
+mount -t vfat "${BOOT_PART}" /mnt/volumio/rootfs/boot
 
 echo "Copying Volumio RootFs"
-sudo cp -pdR build/arm/root/* /mnt/volumio/rootfs
-echo "Copying BANANA-PI boot files"
-# mkdir -p /mnt/volumio/rootfs/boot/bananapi
-# mkdir -p /mnt/volumio/rootfs/boot/bananapi/bananapi
-# mkdir -p /mnt/volumio/rootfs/boot/bananapi/bananapi/linux
-# sudo cp platform-banana/bananapi/boot/uImage /mnt/volumio/rootfs/boot/bananapi/bananapi/linux
-# sudo cp platform-banana/bananapi/boot/uEnv.txt /mnt/volumio/rootfs/boot/bananapi/bananapi/linux
-# sudo cp platform-banana/bananapi/boot/Image.version /mnt/volumio/rootfs/boot/
-# sudo cp platform-banana/bananapi/boot/config* /mnt/volumio/rootfs/boot/
-cp /home/chris/bootp01/boot_rd.cmd /mnt/volumio/rootfs/boot/
-sudo cp platform-banana/bananapi/boot/zImage /mnt/volumio/rootfs/boot/zImage-next
-
-echo "CM update boot partition"
-sudo cp -pdR platform-banana/bananapi/boot/* /mnt/volumio/rootfs/boot
+cp -pdR build/arm/root/* /mnt/volumio/rootfs
+echo "Copying BPI-PRO boot files"
+cp platform-banana/bpi-pro/boot/uImage /mnt/volumio/rootfs/boot/
+cp platform-banana/bootp01/* /mnt/volumio/rootfs/boot/
+# cp platform-banana/bpi-pro/boot/config* /mnt/volumio/rootfs/boot/
+# mkimage -C none -A arm -T script -d platform-banana/bpi-pro/boot/boot.cmd mnt/volumio/rootfs/boot/boot.scr
 
 echo "Copying BPI-PRO modules and firmware"
-mkdir /mnt/volumio/rootfs/lib/
-sudo cp -pdR platform-banana/bananapi/lib/modules /mnt/volumio/rootfs/lib/
-sudo cp -pdR platform-banana/bananapi/lib/firmware /mnt/volumio/rootfs/lib/
-
-
-#TODO: bananapi's should be able to run generic debian
-#sed -i "s/Raspbian/Debian/g" /mnt/volumio/rootfs/etc/issue
+cp -pdR platform-banana/bpi-pro/lib/modules /mnt/volumio/rootfs/lib/
+cp -pdR platform-banana/bpi-pro/lib/firmware /mnt/volumio/rootfs/lib/
 
 sync
 
@@ -155,10 +133,6 @@ su -
 /bpiproconfig.sh
 EOF
 
-echo "Moving uInitrd to where the kernel is"
-# sudo mv /mnt/volumio/rootfs/boot/uInitrd /mnt/volumio/rootfs/boot/bananapi/bananapi/linux/uInitrd
-cp /mnt/volumio/rootfs/boot/* /home/chris/bootsav0
-
 #cleanup
 rm /mnt/volumio/rootfs/bpiproconfig.sh /mnt/volumio/rootfs/root/init
 
@@ -174,7 +148,7 @@ echo "==> BPI-PRO device installed"
 
 #echo "Removing temporary platform files"
 #echo "(you can keep it safely as long as you're sure of no changes)"
-#sudo rm -r platform-bananapi
+#rm -r platform-bananapi
 sync
 
 echo "Preparing rootfs base for SquashFS"
@@ -184,7 +158,7 @@ if [ -d /mnt/squash ]; then
 	rm -rf /mnt/squash/*
 else
 	echo "Creating Volumio SquashFS Temp Dir"
-	sudo mkdir /mnt/squash
+	mkdir /mnt/squash
 fi
 
 echo "Copying Volumio rootfs to Temp Dir"
@@ -205,14 +179,14 @@ rm -rf /mnt/squash
 cp Volumio.sqsh /mnt/volumio/images/volumio_current.sqsh
 sync
 echo "Unmounting Temp Devices"
-sudo umount -l /mnt/volumio/images
-sudo umount -l /mnt/volumio/rootfs/boot
+umount -l /mnt/volumio/images
+umount -l /mnt/volumio/rootfs/boot
 
 echo "Cleaning build environment"
-# rm -rf /mnt/volumio /mnt/boot
+rm -rf /mnt/volumio /mnt/boot
 
-sudo dmsetup remove_all
-sudo losetup -d ${LOOP_DEV}
+dmsetup remove_all
+losetup -d ${LOOP_DEV}
 sync
 
 md5sum "$IMG_FILE" > "${IMG_FILE}.md5"


### PR DESCRIPTION
some minor fixes in build.sh and scripts/bpipro*.sh - can now directly create a bootable Banana-Pi Pro image without manual fine tuning - kept @gkkpch 's kernel for this commit