### PR TITLE
Use consistent filesystem label for volumio_data partition

### DIFF
--- a/scripts/initramfs/init-x86
+++ b/scripts/initramfs/init-x86
@@ -251,7 +251,7 @@ mkdir /mnt/factory
 mount -t vfat ${BOOT_DEVICE}1 /mnt/factory
 if [ -e "/mnt/factory/factory_reset" ]; then
   echo "Executing factory reset..."
-  mkfs.ext4 -F -E stride=2,stripe-width=1024 -b 4096 ${BOOT_DEVICE}3 -L volumiodata
+  mkfs.ext4 -F -E stride=2,stripe-width=1024 -b 4096 ${BOOT_DEVICE}3 -L volumio_data
 
   echo "Factory reset executed: part I"
   cp  /mnt/imgpart/volumio_factory.sqsh /mnt/imgpart/volumio_current.sqsh && rm /mnt/factory/factory_reset
@@ -259,7 +259,7 @@ if [ -e "/mnt/factory/factory_reset" ]; then
 fi
 if [ -e "/mnt/factory/user_data" ]; then
   echo "Deleting User Data..."
-  mkfs.ext4 -F -E stride=2,stripe-width=1024 -b 4096 ${BOOT_DEVICE}3 -L volumiodata
+  mkfs.ext4 -F -E stride=2,stripe-width=1024 -b 4096 ${BOOT_DEVICE}3 -L volumio_data
   rm /mnt/factory/user_data
   
   echo "User Data successfully deleted "

--- a/scripts/x86image.sh
+++ b/scripts/x86image.sh
@@ -42,7 +42,7 @@ echo "Creating filesystems"
 #sudo mkdosfs "${BOOT_PART}"
 sudo mkfs -t vfat -F 32 -n volumioboot "${BOOT_PART}"
 sudo mkfs.ext4 -E stride=2,stripe-width=1024 -b 4096 "${IMG_PART}" -L volumioimg
-sudo mkfs.ext4 -E stride=2,stripe-width=1024 -b 4096 "${DATA_PART}" -L volumiodata
+sudo mkfs.ext4 -E stride=2,stripe-width=1024 -b 4096 "${DATA_PART}" -L volumio_data
 sudo parted -s "${LOOP_DEV}" print
 
 sync

--- a/volumio/etc/udisks-glue.conf
+++ b/volumio/etc/udisks-glue.conf
@@ -2,10 +2,6 @@ filter volumio-data {
         label = volumio_data
 }
 
-filter volumiodata {
-        label = volumiodata
-}
-
 filter ntfs-partitions {
 	optical = false
 	partition_table = false


### PR DESCRIPTION
scripts/x86image.sh uses a different filesystem label than all the other
platform setup scripts for the 'data' partition on the flash image.
To simplify the codebase, make x86 consistent with the other platforms.
The only place the label was used was in the udisks-glue.conf file, to which
it was only recently added (b0400e4baf, Do not mount volumiodata partition).
This patch reverts that change as well.