### PR TITLE
Syncing the scripts, add ftp.nl.debian.org to x86 sources list

### DIFF
--- a/scripts/bpiproconfig.sh
+++ b/scripts/bpiproconfig.sh
@@ -73,6 +73,13 @@ echo "Changing to 'modules=dep'"
 echo "(otherwise Odroid won't boot due to uInitrd 4MB limit)"
 sed -i "s/MODULES=most/MODULES=dep/g" /etc/initramfs-tools/initramfs.conf
 
+echo "Installing winbind here, since it freezes networking"
+apt-get update
+apt-get install -y winbind libnss-winbind
+echo "Cleaning APT Cache"
+rm -f /var/lib/apt/lists/*archive*
+apt-get clean
+
 #First Boot operations
 echo "Signalling the init script to re-size the volumio data partition"
 touch /boot/resize-volumio-datapart

--- a/scripts/cuboxiconfig.sh
+++ b/scripts/cuboxiconfig.sh
@@ -34,8 +34,6 @@ chmod +x /usr/sbin/policy-rc.d
 echo "Installing additional packages"
 apt-get update
 apt-get -y install u-boot-tools
-echo "Installing winbind here, since it freezes networking"
-apt-get install -y winbind libnss-winbind
 echo "Cleaning APT Cache and remove policy file"
 rm -f /var/lib/apt/lists/*archive*
 apt-get clean
@@ -72,6 +70,13 @@ rm /patch
 echo "Changing to 'modules=dep'"
 echo "(otherwise cuboxi may not boot due to size of initrd)"
 sed -i "s/MODULES=most/MODULES=dep/g" /etc/initramfs-tools/initramfs.conf
+
+echo "Installing winbind here, since it freezes networking"
+apt-get update
+apt-get install -y winbind libnss-winbind
+echo "Cleaning APT Cache"
+rm -f /var/lib/apt/lists/*archive*
+apt-get clean
 
 #First Boot operations
 echo "Signalling the init script to re-size the volumio data partition"

--- a/scripts/odroidc2config.sh
+++ b/scripts/odroidc2config.sh
@@ -36,8 +36,6 @@ chmod +x /usr/sbin/policy-rc.d
 echo "Installing additonal packages"
 apt-get update
 apt-get -y install u-boot-tools liblircclient0 lirc fbset
-echo "Installing winbind here, since it freezes networking"
-apt-get install -y winbind libnss-winbind
 
 echo "Cleaning APT Cache and remove policy file"
 rm -f /var/lib/apt/lists/*archive*

--- a/scripts/sparkyconfig.sh
+++ b/scripts/sparkyconfig.sh
@@ -30,8 +30,6 @@ chmod +x /usr/sbin/policy-rc.d
 echo "Installing additonal packages"
 apt-get update
 apt-get -y install u-boot-tools
-echo "Installing winbind here, since it freezes networking"
-apt-get install -y winbind libnss-winbind
 
 echo "Cleaning APT Cache and remove policy file"
 rm -f /var/lib/apt/lists/*archive*
@@ -68,6 +66,13 @@ rm /patch
 echo "Changing to 'modules=dep'"
 echo "(otherwise sparky may not boot due to size of initrd)"
 sed -i "s/MODULES=most/MODULES=dep/g" /etc/initramfs-tools/initramfs.conf
+
+echo "Installing winbind here, since it freezes networking"
+apt-get update
+apt-get install -y winbind libnss-winbind
+echo "Cleaning APT Cache"
+rm -f /var/lib/apt/lists/*archive*
+apt-get clean
 
 #First Boot operations
 echo "Signalling the init script to re-size the volumio data partition"

--- a/scripts/udooneoconfig.sh
+++ b/scripts/udooneoconfig.sh
@@ -33,8 +33,6 @@ chmod +x /usr/sbin/policy-rc.d
 
 apt-get update
 apt-get -y install u-boot-tools
-echo "Installing winbind here, since it freezes networking"
-apt-get install -y winbind libnss-winbind
 echo "Cleaning APT Cache and remove policy file"
 rm -f /var/lib/apt/lists/*archive*
 apt-get clean
@@ -71,6 +69,13 @@ rm /patch
 echo "Changing to 'modules=dep'"
 echo "(otherwise udoo may not boot due to size of initrd)"
 sed -i "s/MODULES=most/MODULES=dep/g" /etc/initramfs-tools/initramfs.conf
+
+echo "Installing winbind here, since it freezes networking"
+apt-get update
+apt-get install -y winbind libnss-winbind
+echo "Cleaning APT Cache"
+rm -f /var/lib/apt/lists/*archive*
+apt-get clean
 
 #First Boot operations
 echo "Signalling the init script to re-size the volumio data partition"

--- a/scripts/udooqdlconfig.sh
+++ b/scripts/udooqdlconfig.sh
@@ -34,8 +34,6 @@ chmod +x /usr/sbin/policy-rc.d
 echo "Installing additional packages"
 apt-get update
 apt-get -y install u-boot-tools
-echo "Installing winbind here, since it freezes networking"
-apt-get install -y winbind libnss-winbind
 echo "Cleaning APT Cache and remove policy file"
 rm -f /var/lib/apt/lists/*archive*
 apt-get clean
@@ -72,6 +70,13 @@ rm /patch
 echo "Changing to 'modules=dep'"
 echo "(otherwise udoo may not boot due to size of initrd)"
 sed -i "s/MODULES=most/MODULES=dep/g" /etc/initramfs-tools/initramfs.conf
+
+echo "Installing winbind here, since it freezes networking"
+apt-get update
+apt-get install -y winbind libnss-winbind
+echo "Cleaning APT Cache"
+rm -f /var/lib/apt/lists/*archive*
+apt-get clean
 
 #First Boot operations
 echo "Signalling the init script to re-size the volumio data partition"

--- a/volumio/etc/apt/sources.list.x86
+++ b/volumio/etc/apt/sources.list.x86
@@ -1,2 +1,2 @@
-deb http://httpredir.debian.org/debian/ jessie main contrib non-free
-deb-src http://httpredir.debian.org/debian/ jessie main contrib non-free
+deb http://ftp.nl.debian.org/debian/ jessie main contrib non-free
+deb-src http://ftp.nl.debian.org/debian/ jessie main contrib non-free


### PR DESCRIPTION
We continue to use ftp.nl.debian.org until we switch to stretch
According to Debian:
"The server deb.debian.org has SRV records in DNS that let apt in **stretch and later** find places."