### PR TITLE
Adding MrEngman drivers for armv6

### DIFF
--- a/scripts/raspberryconfig.sh
+++ b/scripts/raspberryconfig.sh
@@ -173,27 +173,51 @@ KERNEL_REV="884"
 mkdir wifi
 cd wifi
 
-echo "WIFI: 8192EU"
+echo "WIFI: 8192EU for armv7"
 wget https://dl.dropboxusercontent.com/u/80256631/8192eu-$KERNEL_VERSION-v7-$KERNEL_REV.tar.gz
 tar xf 8192eu-$KERNEL_VERSION-v7-$KERNEL_REV.tar.gz
 ./install.sh
 rm -rf *
 
-echo "WIFI: 8812AU"
+echo "WIFI: 8192EU for armv6"
+wget https://dl.dropboxusercontent.com/u/80256631/8192eu-$KERNEL_VERSION-$KERNEL_REV.tar.gz
+tar xf 8192eu-$KERNEL_VERSION-$KERNEL_REV.tar.gz
+./install.sh
+rm -rf *
+
+echo "WIFI: 8812AU for armv7"
 wget https://dl.dropboxusercontent.com/u/80256631/8812au-$KERNEL_VERSION-v7-$KERNEL_REV.tar.gz
 tar xf 8812au-$KERNEL_VERSION-v7-$KERNEL_REV.tar.gz
 ./install.sh
 rm -rf *
 
-echo "WIFI: 8188EU"
+echo "WIFI: 8812AU for armv6"
+wget https://dl.dropboxusercontent.com/u/80256631/8812au-$KERNEL_VERSION-$KERNEL_REV.tar.gz
+tar xf 8812au-$KERNEL_VERSION-$KERNEL_REV.tar.gz
+./install.sh
+rm -rf *
+
+echo "WIFI: 8188EU for armv7"
 wget https://dl.dropboxusercontent.com/u/80256631/8188eu-$KERNEL_VERSION-v7-$KERNEL_REV.tar.gz
 tar xf 8188eu-$KERNEL_VERSION-v7-$KERNEL_REV.tar.gz
 ./install.sh
 rm -rf *
 
-echo "WIFI: MT7610"
+echo "WIFI: 8188EU for armv6"
+wget https://dl.dropboxusercontent.com/u/80256631/8188eu-$KERNEL_VERSION-$KERNEL_REV.tar.gz
+tar xf 8188eu-$KERNEL_VERSION-$KERNEL_REV.tar.gz
+./install.sh
+rm -rf *
+
+echo "WIFI: MT7610 for armv7"
 wget https://dl.dropboxusercontent.com/u/80256631/mt7610-$KERNEL_VERSION-v7-$KERNEL_REV.tar.gz
 tar xf mt7610-$KERNEL_VERSION-v7-$KERNEL_REV.tar.gz
+./install.sh
+rm -rf *
+
+echo "WIFI: MT7610 for armv6"
+wget https://dl.dropboxusercontent.com/u/80256631/mt7610-$KERNEL_VERSION-$KERNEL_REV.tar.gz
+tar xf mt7610-$KERNEL_VERSION-$KERNEL_REV.tar.gz
 ./install.sh
 rm -rf *
 


### PR DESCRIPTION
Replaces #154
After more careful reading, depmod for armv7 and armv6 in each install.sh will work under armv7 QEMU

BTW: if depmod in firststart.sh was for this, then it can be safely removed (anyway a reboot is required for such change to take effect, and it does not seem firststart.sh triggers a reboot)