### PR TITLE
Initial support for PiZero W wireless

### DIFF
--- a/scripts/raspberryconfig.sh
+++ b/scripts/raspberryconfig.sh
@@ -81,7 +81,7 @@ apt-mark hold raspberrypi-kernel raspberrypi-bootloader   #libraspberrypi0 depen
 
 if [ "$KERNEL_VERSION" = "4.4.9" ]; then       # probably won't be necessary in future kernels 
 echo "Adding initial support for PiZero W wireless on 4.4.9 kernel"
-wget -P /boot/overlays/ https://github.com/raspberrypi/firmware/raw/stable/boot/bcm2708-rpi-0-w.dtb
+wget -P /boot/. https://github.com/raspberrypi/firmware/raw/stable/boot/bcm2708-rpi-0-w.dtb
 fi
 
 echo "Adding PI3 & PiZero W Wireless firmware"

--- a/scripts/raspberryconfig.sh
+++ b/scripts/raspberryconfig.sh
@@ -79,12 +79,16 @@ Pin: release *
 Pin-Priority: -1" > /etc/apt/preferences
 apt-mark hold raspberrypi-kernel raspberrypi-bootloader   #libraspberrypi0 depends on raspberrypi-bootloader
 
+if [ "$KERNEL_VERSION" = "4.4.9" ]; then       # probably won't be necessary in future kernels 
+echo "Adding initial support for PiZero W wireless on 4.4.9 kernel"
+wget -P /boot/overlays/ https://github.com/raspberrypi/firmware/raw/stable/boot/bcm2708-rpi-0-w.dtb
+fi
 
-echo "Adding PI3 Wireless firmware"
+echo "Adding PI3 & PiZero W Wireless firmware"
 wget http://repo.volumio.org/Volumio2/wireless-firmwares/brcmfmac43430-sdio.txt -P /lib/firmware/brcm/
 wget http://repo.volumio.org/Volumio2/wireless-firmwares/brcmfmac43430-sdio.bin -P /lib/firmware/brcm/
 
-echo "Adding PI WIFI Wireless firmware"
+echo "Adding PI WIFI Wireless dongle firmware"
 wget http://repo.volumio.org/Volumio2/wireless-firmwares/brcmfmac43143.bin -P /lib/firmware/brcm/
 
 #echo "Adding raspi-config"


### PR DESCRIPTION
Add necessary bcm2708-rpi-0-w.dtb from 4.4 stable branch
Probably won't be necessary anymore when Kernel is updated, so it's a conditional install for now

Reported working by several users in [Forum](https://volumio.org/forum/with-new-rpi-zero-t6050-20.html#p29932).
(note: uses same chipset than Pi3 so no need for new wireless firmware)