### PR TITLE
udev rules to prioritize network interfaces

### DIFF
--- a/scripts/configure.sh
+++ b/scripts/configure.sh
@@ -86,6 +86,10 @@ cp -rp volumio/etc/dhcpcd.conf build/$BUILD/root/etc/
 #wifi pre script
 cp volumio/bin/wifistart.sh build/$BUILD/root/bin/wifistart.sh
 chmod a+x build/$BUILD/root/bin/wifistart.sh
+#udev script
+cp volumio/bin/rename_netiface0.sh build/$BUILD/root/bin/rename_netiface0.sh
+chmod a+x build/$BUILD/root/bin/rename_netiface0.sh
+
 echo 'Done Copying Custom Volumio System Files'
 
 echo "Stripping binaries and libraries to save space"

--- a/scripts/raspberryconfig.sh
+++ b/scripts/raspberryconfig.sh
@@ -167,23 +167,6 @@ ln -s /opt/vc/lib/libvchiq_arm.so /usr/lib/libvchiq_arm.so
 ln -s /opt/vc/bin/vcgencmd /usr/bin/vcgencmd
 ln -s /opt/vc/lib/libvcos.so /usr/lib/libvcos.so
 
-echo "Adding raspi blackist"
-#this way if another USB WIFI dongle is present, it will always be the default one
-echo "
-#wifi
-blacklist brcmfmac
-blacklist brcmutil
-" > /etc/modprobe.d/raspi-blacklist.conf
-
-#Load PI3 wifi module just before wifi stack starts
-echo "
-#!/bin/sh
-sudo /sbin/modprobe brcmfmac
-sudo /sbin/modprobe brcmutil
-sudo /sbin/iw dev wlan0 set power_save off
-" >> /bin/wifistart.sh
-echo "Give proper permissions to wifistart.sh"
-chmod a+x /bin/wifistart.sh
 
 echo "Installing Wireless drivers for 8192eu, 8812au, 8188eu and mt7610. Many thanks mrengman"
 

--- a/scripts/raspberryconfig.sh
+++ b/scripts/raspberryconfig.sh
@@ -167,12 +167,6 @@ ln -s /opt/vc/lib/libvchiq_arm.so /usr/lib/libvchiq_arm.so
 ln -s /opt/vc/bin/vcgencmd /usr/bin/vcgencmd
 ln -s /opt/vc/lib/libvcos.so /usr/lib/libvcos.so
 
-echo "Setting udev rules to give USB network adapters priority over Built-in interfaces if connected"
-echo "# Give priority to wlan or eth USB network dongles if connected
-ACTION==\"add\", SUBSYSTEM==\"net\", SUBSYSTEMS==\"usb\", KERNEL==\"wlan*\", ATTR{type}==\"1\", NAME=\"wlan0\"
-ACTION==\"add\", SUBSYSTEM==\"net\", SUBSYSTEMS==\"usb\", KERNEL==\"eth*\", DRIVERS!=\"smsc95*\", ATTR{type}==\"1\", NAME=\"eth0\"
-" > /etc/udev/rules.d/70-persistent-net.rules
-
 echo "Installing Wireless drivers for 8192eu, 8812au, 8188eu and mt7610. Many thanks mrengman"
 
 mkdir wifi

--- a/scripts/raspberryconfig.sh
+++ b/scripts/raspberryconfig.sh
@@ -167,6 +167,11 @@ ln -s /opt/vc/lib/libvchiq_arm.so /usr/lib/libvchiq_arm.so
 ln -s /opt/vc/bin/vcgencmd /usr/bin/vcgencmd
 ln -s /opt/vc/lib/libvcos.so /usr/lib/libvcos.so
 
+echo "Setting udev rules to give USB network adapters priority over Built-in interfaces if connected"
+echo "# Give priority to wlan or eth USB network dongles if connected
+ACTION==\"add\", SUBSYSTEM==\"net\", SUBSYSTEMS==\"usb\", KERNEL==\"wlan*\", ATTR{type}==\"1\", NAME=\"wlan0\"
+ACTION==\"add\", SUBSYSTEM==\"net\", SUBSYSTEMS==\"usb\", KERNEL==\"eth*\", DRIVERS!=\"smsc95*\", ATTR{type}==\"1\", NAME=\"eth0\""
+> /etc/udev/rules.d/70-persistent-net.rules
 
 echo "Installing Wireless drivers for 8192eu, 8812au, 8188eu and mt7610. Many thanks mrengman"
 

--- a/scripts/raspberryconfig.sh
+++ b/scripts/raspberryconfig.sh
@@ -170,8 +170,8 @@ ln -s /opt/vc/lib/libvcos.so /usr/lib/libvcos.so
 echo "Setting udev rules to give USB network adapters priority over Built-in interfaces if connected"
 echo "# Give priority to wlan or eth USB network dongles if connected
 ACTION==\"add\", SUBSYSTEM==\"net\", SUBSYSTEMS==\"usb\", KERNEL==\"wlan*\", ATTR{type}==\"1\", NAME=\"wlan0\"
-ACTION==\"add\", SUBSYSTEM==\"net\", SUBSYSTEMS==\"usb\", KERNEL==\"eth*\", DRIVERS!=\"smsc95*\", ATTR{type}==\"1\", NAME=\"eth0\""
-> /etc/udev/rules.d/70-persistent-net.rules
+ACTION==\"add\", SUBSYSTEM==\"net\", SUBSYSTEMS==\"usb\", KERNEL==\"eth*\", DRIVERS!=\"smsc95*\", ATTR{type}==\"1\", NAME=\"eth0\"
+" > /etc/udev/rules.d/70-persistent-net.rules
 
 echo "Installing Wireless drivers for 8192eu, 8812au, 8188eu and mt7610. Many thanks mrengman"
 

--- a/scripts/raspberryconfig.sh
+++ b/scripts/raspberryconfig.sh
@@ -167,6 +167,9 @@ ln -s /opt/vc/lib/libvchiq_arm.so /usr/lib/libvchiq_arm.so
 ln -s /opt/vc/bin/vcgencmd /usr/bin/vcgencmd
 ln -s /opt/vc/lib/libvcos.so /usr/lib/libvcos.so
 
+# changing external ethX priority rule for Pi as built-in eth _is_ on USB (smsc95xx driver)
+sed -i 's/KERNEL==\"eth/DRIVERS!=\"smsc95xx\", &/' /etc/udev/rules.d/99-Volumio-net.rules
+
 echo "Installing Wireless drivers for 8192eu, 8812au, 8188eu and mt7610. Many thanks mrengman"
 
 mkdir wifi

--- a/volumio/bin/rename_netiface0.sh
+++ b/volumio/bin/rename_netiface0.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
-# This script is called by Volumio udev rule to set/swap name to eth0 or wlan0
-# as udev renaming sometimes fails with some module drivers
-# it assumes legacy style interface names such as ethX, wlanX
+# This script is called by Volumio udev rule to set/swap name for eth0 or wlan0
+# since udev renaming sometimes fails with some module drivers
+# It assumes System uses legacy style interface names such as ethX, wlanX
 
 
 if_name=$1
@@ -9,8 +9,8 @@ if_type=${if_name%%[0-9]*}
 
 ifconfig $if_type"0" down
 ifconfig $if_name down
-ip link set dev $if_type"0" name temp_name
+ip link set dev $if_type"0" name $if_type"_temp_name"
 ip link set dev $if_name name $if_type"0"
-ip link set dev temp_name name $if_name
+ip link set dev $if_type"_temp_name" name $if_name
 ifconfig $if_name up
 ifconfig $if_type"0" up

--- a/volumio/bin/rename_netiface0.sh
+++ b/volumio/bin/rename_netiface0.sh
@@ -1,0 +1,16 @@
+#!/bin/sh
+# This script is called by Volumio udev rule to set/swap name to eth0 or wlan0
+# as udev renaming sometimes fails with some module drivers
+# it assumes legacy style interface names such as ethX, wlanX
+
+
+if_name=$1
+if_type=${if_name%%[0-9]*}
+
+ifconfig $if_type"0" down
+ifconfig $if_name down
+ip link set dev $if_type"0" name temp_name
+ip link set dev $if_name name $if_type"0"
+ip link set dev temp_name name $if_name
+ifconfig $if_name up
+ifconfig $if_type"0" up

--- a/volumio/bin/wifistart.sh
+++ b/volumio/bin/wifistart.sh
@@ -1,2 +1,1 @@
 #!/bin/sh
-sudo /sbin/iw dev wlan0 set power_save off

--- a/volumio/bin/wifistart.sh
+++ b/volumio/bin/wifistart.sh
@@ -1,1 +1,2 @@
 #!/bin/sh
+sudo /sbin/iw dev wlan0 set power_save off

--- a/volumio/etc/udev/rules.d/99-Volumio-net.rules
+++ b/volumio/etc/udev/rules.d/99-Volumio-net.rules
@@ -1,2 +1,2 @@
-ACTION=="add", SUBSYSTEM=="net", SUBSYSTEMS=="usb", ENV{DEVTYPE}=="wlan", ATTR{type}=="1", KERNEL=="wlan*", KERNEL!="wlan0", RUN+="/bin/rename_netiface0.sh '%E{INTERFACE}'"
-ACTION=="add", SUBSYSTEM=="net", SUBSYSTEMS=="usb", ENV{DEVTYPE}!="wlan", ATTR{type}=="1", KERNEL=="eth*", KERNEL!="eth0", RUN+="/bin/rename_netiface0.sh '%E{INTERFACE}'"
+ACTION=="add", SUBSYSTEM=="net", SUBSYSTEMS=="usb", ENV{DEVTYPE}=="wlan", ATTR{type}=="1", KERNEL=="wlan[1-9]*", RUN+="/bin/rename_netiface0.sh '%E{INTERFACE}'"
+ACTION=="add", SUBSYSTEM=="net", SUBSYSTEMS=="usb", ENV{DEVTYPE}!="wlan", ATTR{type}=="1", KERNEL=="eth[1-9]*", RUN+="/bin/rename_netiface0.sh '%E{INTERFACE}'"

--- a/volumio/etc/udev/rules.d/99-Volumio-net.rules
+++ b/volumio/etc/udev/rules.d/99-Volumio-net.rules
@@ -1,0 +1,2 @@
+ACTION=="add", SUBSYSTEM=="net", SUBSYSTEMS=="usb", ENV{DEVTYPE}=="wlan", ATTR{type}=="1", KERNEL=="wlan*", KERNEL!="wlan0", RUN+="/bin/rename_netiface0.sh '%E{INTERFACE}'"
+ACTION=="add", SUBSYSTEM=="net", SUBSYSTEMS=="usb", ENV{DEVTYPE}!="wlan", ATTR{type}=="1", KERNEL=="eth*", KERNEL!="eth0", RUN+="/bin/rename_netiface0.sh '%E{INTERFACE}'"

--- a/volumio/etc/udev/rules.d/99-Volumio-net.rules
+++ b/volumio/etc/udev/rules.d/99-Volumio-net.rules
@@ -1,2 +1,3 @@
+# Give Volumio interface priority to external wlan or eth USB network dongles if connected
 ACTION=="add", SUBSYSTEM=="net", SUBSYSTEMS=="usb", ENV{DEVTYPE}=="wlan", ATTR{type}=="1", KERNEL=="wlan[1-9]*", RUN+="/bin/rename_netiface0.sh '%E{INTERFACE}'"
 ACTION=="add", SUBSYSTEM=="net", SUBSYSTEMS=="usb", ENV{DEVTYPE}!="wlan", ATTR{type}=="1", KERNEL=="eth[1-9]*", RUN+="/bin/rename_netiface0.sh '%E{INTERFACE}'"


### PR DESCRIPTION
This PR replaces [Pi3-specific driver blacklist-based filter](https://github.com/volumio/Build/issues/150) by udev rule.
It brings several benefits:
- avoids unwanted brcmfmac/brcmutil driver loads on all Pi platforms
- prioritizes plugged-in external USB network interfaces over built-in (wlan & eth)
- generic for all platforms (+added customization for Pi built-in eth which **is** on USB)

This fix has been tested with several devices and dongles.