### PR TITLE
Pi: add pi3-disable-wifi.dtbo

### DIFF
--- a/scripts/raspberryconfig.sh
+++ b/scripts/raspberryconfig.sh
@@ -83,7 +83,7 @@ if [ "$KERNEL_VERSION" = "4.4.9" ]; then       # probably won't be necessary in 
 echo "Adding initial support for PiZero W wireless on 4.4.9 kernel"
 wget -P /boot/. https://github.com/raspberrypi/firmware/raw/stable/boot/bcm2708-rpi-0-w.dtb
 echo "Adding support for dtoverlay=pi3-disable-wifi on 4.4.9 kernel"
-wget -P /boot/overlays/. https://github.com/raspberrypi/firmware/blob/stable/boot/overlays/pi3-disable-wifi.dtbo
+wget -P /boot/overlays/. https://github.com/raspberrypi/firmware/raw/stable/boot/overlays/pi3-disable-wifi.dtbo
 fi
 
 echo "Adding PI3 & PiZero W Wireless firmware"

--- a/scripts/raspberryconfig.sh
+++ b/scripts/raspberryconfig.sh
@@ -83,7 +83,7 @@ if [ "$KERNEL_VERSION" = "4.4.9" ]; then       # probably won't be necessary in 
 echo "Adding initial support for PiZero W wireless on 4.4.9 kernel"
 wget -P /boot/. https://github.com/raspberrypi/firmware/raw/stable/boot/bcm2708-rpi-0-w.dtb
 echo "Adding support for dtoverlay=pi3-disable-wifi on 4.4.9 kernel"
-wget -P /boot/overlays/. https://github.com/Hexxeh/rpi-firmware/blob/stable/overlays/pi3-disable-wifi.dtbo
+wget -P /boot/overlays/. https://github.com/raspberrypi/firmware/blob/stable/boot/overlays/pi3-disable-wifi.dtbo
 fi
 
 echo "Adding PI3 & PiZero W Wireless firmware"

--- a/scripts/raspberryconfig.sh
+++ b/scripts/raspberryconfig.sh
@@ -82,6 +82,8 @@ apt-mark hold raspberrypi-kernel raspberrypi-bootloader   #libraspberrypi0 depen
 if [ "$KERNEL_VERSION" = "4.4.9" ]; then       # probably won't be necessary in future kernels 
 echo "Adding initial support for PiZero W wireless on 4.4.9 kernel"
 wget -P /boot/. https://github.com/raspberrypi/firmware/raw/stable/boot/bcm2708-rpi-0-w.dtb
+echo "Adding support for dtoverlay=pi3-disable-wifi on 4.4.9 kernel"
+wget -P /boot/overlays/. https://github.com/Hexxeh/rpi-firmware/blob/stable/overlays/pi3-disable-wifi.dtbo
 fi
 
 echo "Adding PI3 & PiZero W Wireless firmware"


### PR DESCRIPTION
This allows users to completely turn off pi3 wireless chip (even radio), by setting `dtoverlay=pi3-disable-wifi` in `/boot/config.txt`

Tested working in this [Forum thread](https://volumio.org/forum/rpi-and-wifi-dongle-t6099-10.html#p29954)

Note that as per current issue in https://github.com/volumio/Volumio2/issues/946 , i2s_dacs/index.js always overwrites existing content of `/boot/config.txt`.
This compromises any changes made into `/boot/config.txt` by users and/or possibly required by some plugins.
That issue needs a fix, so that such features can be consistently used.
