### PR TITLE
Add firmware for Atheros AR9170 wifi USB dongle

### DIFF
--- a/recipes/arm-dev.conf
+++ b/recipes/arm-dev.conf
@@ -54,7 +54,7 @@ keyring=debian-archive-keyring
 suite=jessie
 
 [Firmware]
-packages=firmware-atheros firmware-ralink firmware-realtek
+packages=firmware-atheros firmware-ralink firmware-realtek firmware-brcm80211 firmware-linux-free
 source=http://mirrordirector.raspbian.org/raspbian
 keyring=debian-archive-keyring
 components=main non-free

--- a/recipes/arm.conf
+++ b/recipes/arm.conf
@@ -48,7 +48,7 @@ keyring=debian-archive-keyring
 suite=jessie
 
 [Firmware]
-packages=firmware-atheros firmware-ralink firmware-realtek firmware-brcm80211
+packages=firmware-atheros firmware-ralink firmware-realtek firmware-brcm80211 firmware-linux-free
 source=http://mirrordirector.raspbian.org/raspbian
 keyring=debian-archive-keyring
 components=main non-free

--- a/recipes/armv7-dev.conf
+++ b/recipes/armv7-dev.conf
@@ -54,7 +54,7 @@ keyring=debian-archive-keyring
 suite=jessie
 
 [Firmware]
-packages=firmware-atheros firmware-ralink firmware-realtek firmware-brcm80211
+packages=firmware-atheros firmware-ralink firmware-realtek firmware-brcm80211 firmware-linux-free
 source=http://ftp.nl.debian.org/debian
 keyring=debian-archive-keyring
 components=main non-free

--- a/recipes/armv7.conf
+++ b/recipes/armv7.conf
@@ -48,7 +48,7 @@ keyring=debian-archive-keyring
 suite=jessie
 
 [Firmware]
-packages=firmware-atheros firmware-ralink firmware-realtek firmware-brcm80211
+packages=firmware-atheros firmware-ralink firmware-realtek firmware-brcm80211 firmware-linux-free
 source=http://ftp.nl.debian.org/debian
 keyring=debian-archive-keyring
 components=main non-free

--- a/recipes/armv8-dev.conf
+++ b/recipes/armv8-dev.conf
@@ -60,7 +60,7 @@ keyring=debian-archive-keyring
 suite=jessie
 
 [Firmware]
-packages=firmware-atheros firmware-ralink firmware-realtek firmware-brcm80211
+packages=firmware-atheros firmware-ralink firmware-realtek firmware-brcm80211 firmware-linux-free
 source=http://ftp.nl.debian.org/debian
 keyring=debian-archive-keyring
 components=main non-free

--- a/recipes/armv8.conf
+++ b/recipes/armv8.conf
@@ -48,7 +48,7 @@ keyring=debian-archive-keyring
 suite=jessie
 
 [Firmware]
-packages=firmware-atheros firmware-ralink firmware-realtek firmware-brcm80211
+packages=firmware-atheros firmware-ralink firmware-realtek firmware-brcm80211 firmware-linux-free
 source=http://ftp.nl.debian.org/debian
 keyring=debian-archive-keyring
 components=main non-free


### PR DESCRIPTION
[Reported working](https://github.com/volumio/Build/pull/167#issuecomment-286980405) by @chsims1 with [that addition](https://github.com/volumio/Build/pull/167#issuecomment-286470758) on Pi platform (client to Home wifi AP only, not Volumio Hotspot at this point).

Actual carl9170 driver is in kernel, but carl9170 firmware is in `firmware-linux-free` (rather than in `firmware-atheros`! )

Shall I also add package for other builds?
