### PR TITLE
 CRDA install clean-up

### DIFF
--- a/recipes/arm-dev.conf
+++ b/recipes/arm-dev.conf
@@ -18,7 +18,7 @@ keyring=debian-archive-keyring
 suite=jessie
 
 [Net]
-packages=netbase ifupdown iproute net-tools iptables isc-dhcp-client openssh-server wireless-tools telnet iputils-ping libgnutls-openssl27 libnl-3-200 libnl-genl-3-200 libpcsclite1 rfkill wpasupplicant libavahi-compat-libdnssd-dev
+packages=netbase ifupdown iproute net-tools iptables isc-dhcp-client openssh-server wireless-tools telnet iputils-ping libgnutls-openssl27 libnl-3-200 libnl-genl-3-200 libpcsclite1 rfkill wpasupplicant libavahi-compat-libdnssd-dev wireless-regdb crda
 source=http://mirrordirector.raspbian.org/raspbian
 keyring=debian-archive-keyring
 suite=jessie

--- a/recipes/x86-dev.conf
+++ b/recipes/x86-dev.conf
@@ -24,7 +24,7 @@ keyring=debian-archive-keyring
 suite=wheezy
 
 [Net]
-packages=netbase ifupdown iproute net-tools iptables isc-dhcp-client openssh-server wireless-tools telnet iputils-ping libgnutls-openssl27 libnl-3-200 libnl-genl-3-200 libpcsclite1 rfkill wpasupplicant libavahi-compat-libdnssd-dev
+packages=netbase ifupdown iproute net-tools iptables isc-dhcp-client openssh-server wireless-tools telnet iputils-ping libgnutls-openssl27 libnl-3-200 libnl-genl-3-200 libpcsclite1 rfkill wpasupplicant libavahi-compat-libdnssd-dev wireless-regdb crda
 source=http://httpredir.debian.org/debian
 keyring=debian-archive-keyring
 suite=jessie

--- a/scripts/raspberryconfig.sh
+++ b/scripts/raspberryconfig.sh
@@ -120,9 +120,6 @@ SUBSYSTEM=="gpio*", PROGRAM="/bin/sh -c' "'chown -R root:gpio /sys/class/gpio &&
 echo "adding volumio to gpio group"
 sudo adduser volumio gpio
 
-echo "Fixing crda domain error"
-apt-get -y install crda wireless-regdb
-
 echo "Removing unneeded binaries"
 apt-get -y remove binutils
 


### PR DESCRIPTION
is already in `arm.conf` recipe, so removing duplicate install in `raspberryconfig.sh`
It is also present in all other platforms recipes, except in `arm-dev.conf` and `x86-dev.conf`, so adding there too.

BTW, those latter 2 config files seem out-of-sync with other platforms -dev instances...
more sanity-check adjustments might be needed if still of use.