### PR TITLE
Pi: bump next kernel test case to 4.9.20

### DIFF
--- a/scripts/raspberryconfig.sh
+++ b/scripts/raspberryconfig.sh
@@ -66,10 +66,10 @@ case $KERNEL_VERSION in
       KERNEL_BRANCH="stable"
       KERNEL_COMMIT="15ffab5493d74b12194e6bfc5bbb1c0f71140155"
       ;; 
-    "4.9.17")
-      KERNEL_REV="981"
+    "4.9.20")
+      KERNEL_REV="985"
       KERNEL_BRANCH="master"
-      KERNEL_COMMIT="41561448388d90f19f2e40ac62ce1c21c2e064ec"
+      KERNEL_COMMIT="3ff94f1fc459f88d3e2530542fb609643a7bd1a6"
       ;; 
 esac
 


### PR DESCRIPTION
4.9.20 now includes up-to date pisound, allo & hifiberry DAC drivers & overlays
This change does NOT affect standard build of Volumio on 4.4.9