### PR TITLE
Hostapd-edimax use: improved compatibility

### DIFF
--- a/volumio/bin/hotspot.sh
+++ b/volumio/bin/hotspot.sh
@@ -2,10 +2,10 @@
 
 case "$1" in
 'start')
-DRIVER=`/sbin/ethtool -i wlan0 | grep driver | awk -F": " '{print $2}'`
+MODULE=$(basename $(readlink /sys/class/net/wlan0/device/driver/module))
 ARCH=`/usr/bin/dpkg --print-architecture`
 
-if [ $DRIVER = "rtl8192cu" -a $ARCH = "armhf" ] ; then
+if [ $MODULE = "8192cu" -a $ARCH = "armhf" ] && !(modinfo $MODULE | grep "cfg80211" > /dev/null) ; then
   echo "Launching Hostapd Edimax"
 /usr/sbin/hostapd-edimax /etc/hostapd/hostapd-edimax.conf
 else

--- a/volumio/bin/hotspot.sh
+++ b/volumio/bin/hotspot.sh
@@ -5,7 +5,7 @@ case "$1" in
 MODULE=$(basename $(readlink /sys/class/net/wlan0/device/driver/module))
 ARCH=`/usr/bin/dpkg --print-architecture`
 
-if [ $MODULE = "8192cu" -a $ARCH = "armhf" ] && !(modinfo $MODULE | grep "cfg80211" > /dev/null) ; then
+if [ $MODULE = "8192cu" -a $ARCH = "armhf" ] && !(modinfo $MODULE | grep '^depends:.*cfg80211.*' > /dev/null) ; then
   echo "Launching Hostapd Edimax"
 /usr/sbin/hostapd-edimax /etc/hostapd/hostapd-edimax.conf
 else


### PR DESCRIPTION
Custom `hostapd-edimax` is only launched if the loaded 8192cu module driver does NOT support `cfg80211` (as with pre 4.4.13 kernel)
Indeed, since 4.4.13 Pi kernel release, 8192cu module driver has been enhanced (without changing its version number) to include `cfg80211` support, and therefore now requires standard `hostapd`.

Note: this fix does not alter operations on current 4.4.9-based Volumio, as it indeed keeps using `hostapd-edimax` as previously.
It will also work with other ARM platform according to the 8192cu driver they may use.