### PR TITLE
Default DNS settings update

### DIFF
--- a/scripts/volumioconfig.sh
+++ b/scripts/volumioconfig.sh
@@ -432,11 +432,6 @@ echo "Hostapd conf files"
 cp /etc/hostapd/hostapd.conf /etc/hostapd/hostapd.tmpl
 chmod -R 777 /etc/hostapd
 
-echo "Setting fallback DNS with Google's DNS"
-echo "# Google nameservers
-nameserver 8.8.8.8
-nameserver 8.8.4.4" >> /etc/resolv.conf.tail
-
 echo "Removing Avahi Service for UDISK-SSH"
 rm /etc/avahi/services/udisks.service
 

--- a/scripts/volumioconfig.sh
+++ b/scripts/volumioconfig.sh
@@ -91,7 +91,7 @@ alias volumio="/volumio/app/plugins/system_controller/volumio_command_line_clien
 
 #Sudoers Nopasswd
 echo 'Adding Safe Sudoers NoPassw permissions'
-echo "volumio ALL=(ALL) NOPASSWD: /sbin/poweroff,/sbin/shutdown,/sbin/reboot,/sbin/halt,/bin/systemctl,/usr/bin/apt-get,/usr/sbin/update-rc.d,/usr/bin/gpio,/bin/mount,/bin/umount,/sbin/iwconfig,/sbin/iwlist,/sbin/ifconfig,/usr/bin/killall,/bin/ip,/usr/sbin/service,/etc/init.d/netplug,/bin/journalctl,/bin/chmod,/sbin/ethtool,/usr/sbin/alsactl,/bin/tar,/usr/bin/dtoverlay,/sbin/dhclient,/usr/sbin/i2cdetect,/sbin/dhcpcd,/usr/bin/alsactl,/bin/mv,/sbin/iw,/bin/hostname,/sbin/modprobe,/sbin/iwgetid" >> /etc/sudoers
+echo "volumio ALL=(ALL) NOPASSWD: /sbin/poweroff,/sbin/shutdown,/sbin/reboot,/sbin/halt,/bin/systemctl,/usr/bin/apt-get,/usr/sbin/update-rc.d,/usr/bin/gpio,/bin/mount,/bin/umount,/sbin/iwconfig,/sbin/iwlist,/sbin/ifconfig,/usr/bin/killall,/bin/ip,/usr/sbin/service,/etc/init.d/netplug,/bin/journalctl,/bin/chmod,/sbin/ethtool,/usr/sbin/alsactl,/bin/tar,/usr/bin/dtoverlay,/sbin/dhclient,/usr/sbin/i2cdetect,/sbin/dhcpcd,/usr/bin/alsactl,/bin/mv,/sbin/iw,/bin/hostname,/sbin/modprobe,/sbin/iwgetid,/bin/ln,/usr/bin/unlink" >> /etc/sudoers
 
 echo volumio > /etc/hostname
 chmod 777 /etc/hostname
@@ -434,6 +434,13 @@ chmod -R 777 /etc/hostapd
 
 echo "Empty resolv.conf.head for custom DNS settings"
 touch /etc/resolv.conf.head
+
+echo "Setting fallback DNS with OpenDNS nameservers"
+echo "# OpenDNS nameservers
+nameserver 208.67.222.222
+nameserver 208.67.220.220" > /etc/resolv.conf.tail.tmpl
+ln -s /etc/resolv.conf.tail.tmpl /etc/resolv.conf.tail
+chmod 666 /etc/resolv.conf.*
 
 echo "Removing Avahi Service for UDISK-SSH"
 rm /etc/avahi/services/udisks.service

--- a/scripts/volumioconfig.sh
+++ b/scripts/volumioconfig.sh
@@ -432,6 +432,9 @@ echo "Hostapd conf files"
 cp /etc/hostapd/hostapd.conf /etc/hostapd/hostapd.tmpl
 chmod -R 777 /etc/hostapd
 
+echo "Empty resolv.conf.head for custom DNS settings"
+touch /etc/resolv.conf.head
+
 echo "Removing Avahi Service for UDISK-SSH"
 rm /etc/avahi/services/udisks.service
 


### PR DESCRIPTION
~~This Google DNS fallback is no longer necessary (and potentially conflicting) with addition of custom DNS settings in Volumio2~~
This PR is updating default DNS information (`.head` and `.tail`) to enable custom DNS settings by https://github.com/volumio/Volumio2/pull/1061:

Both PRs should be merged at same time.