### PR TITLE
Pi: removing redundant firmware installs

### DIFF
--- a/scripts/raspberryconfig.sh
+++ b/scripts/raspberryconfig.sh
@@ -102,13 +102,6 @@ echo "Adding support for dtoverlay=pi3-disable-wifi on 4.4.9 kernel"
 wget -P /boot/overlays/. https://github.com/Hexxeh/rpi-firmware/raw/$FIRMWARE_COMMIT/overlays/pi3-disable-wifi.dtbo
 fi
 
-echo "Adding PI3 & PiZero W Wireless firmware"
-wget http://repo.volumio.org/Volumio2/wireless-firmwares/brcmfmac43430-sdio.txt -P /lib/firmware/brcm/
-wget http://repo.volumio.org/Volumio2/wireless-firmwares/brcmfmac43430-sdio.bin -P /lib/firmware/brcm/
-
-echo "Adding PI WIFI Wireless dongle firmware"
-wget http://repo.volumio.org/Volumio2/wireless-firmwares/brcmfmac43143.bin -P /lib/firmware/brcm/
-
 #echo "Adding raspi-config"
 #wget -P /raspi http://archive.raspberrypi.org/debian/pool/main/r/raspi-config/raspi-config_20151019_all.deb
 #dpkg -i /raspi/raspi-config_20151019_all.deb


### PR DESCRIPTION
no longer needed since addition of firmware-brcm80211 package on Mar 14, 2016 as per https://github.com/volumio/Build/commit/4ad9736e8ec06422fd61813fb200925e91f907ff#diff-e745f2542baf16ec9199d5c899b4900c

```
apt-file list firmware-brcm80211
firmware-brcm80211: /lib/firmware/brcm/bcm43xx-0.fw
firmware-brcm80211: /lib/firmware/brcm/bcm43xx_hdr-0.fw
firmware-brcm80211: /lib/firmware/brcm/brcmfmac43143-sdio.bin
firmware-brcm80211: /lib/firmware/brcm/brcmfmac43143.bin
firmware-brcm80211: /lib/firmware/brcm/brcmfmac43241b0-sdio.bin
firmware-brcm80211: /lib/firmware/brcm/brcmfmac43241b4-sdio.bin
firmware-brcm80211: /lib/firmware/brcm/brcmfmac4329-sdio.bin
firmware-brcm80211: /lib/firmware/brcm/brcmfmac4330-sdio.bin
firmware-brcm80211: /lib/firmware/brcm/brcmfmac4334-sdio.bin
firmware-brcm80211: /lib/firmware/brcm/brcmfmac4335-sdio.bin
firmware-brcm80211: /lib/firmware/brcm/brcmfmac43362-sdio.bin
firmware-brcm80211: /lib/firmware/brcm/brcmfmac43430-sdio.bin
firmware-brcm80211: /lib/firmware/brcm/brcmfmac43430-sdio.txt
firmware-brcm80211: /lib/firmware/brcm/brcmfmac4354-sdio.bin
firmware-brcm80211: /usr/share/bug/firmware-brcm80211/presubj
firmware-brcm80211: /usr/share/doc/firmware-brcm80211/changelog.gz
firmware-brcm80211: /usr/share/doc/firmware-brcm80211/copyright
```