### PR TITLE
Pi: use Foundation-provided firmware-nonfree

### DIFF
--- a/recipes/arm-dev.conf
+++ b/recipes/arm-dev.conf
@@ -1,7 +1,7 @@
 [General]
 noauth=true
 unpack=true
-debootstrap=Base Net Utils Assets FS Spotify Firmware DevTools
+debootstrap=Base Net Utils Assets FS Spotify Firmware_base Firmware_Foundation DevTools
 aptsources=Debian
 cleanup=true
 arch=armhf
@@ -53,9 +53,16 @@ source=http://mirrordirector.raspbian.org/raspbian
 keyring=debian-archive-keyring
 suite=jessie
 
-[Firmware]
-packages=firmware-atheros firmware-ralink firmware-realtek firmware-brcm80211 firmware-linux-free
+[Firmware_base]
+packages=firmware-linux-free
 source=http://mirrordirector.raspbian.org/raspbian
 keyring=debian-archive-keyring
 components=main non-free
+suite=jessie
+
+[Firmware_Foundation]
+packages=firmware-atheros firmware-ralink firmware-realtek firmware-brcm80211
+source=http://archive.raspberrypi.org/debian/
+keyring=debian-archive-keyring
+components=main
 suite=jessie

--- a/recipes/arm.conf
+++ b/recipes/arm.conf
@@ -1,7 +1,7 @@
 [General]
 noauth=true
 unpack=true
-debootstrap=Base Net Utils Assets FS Firmware
+debootstrap=Base Net Utils Assets FS Firmware_base Firmware_Foundation
 aptsources=Debian
 cleanup=true
 arch=armhf
@@ -47,9 +47,16 @@ source=http://mirrordirector.raspbian.org/raspbian
 keyring=debian-archive-keyring
 suite=jessie
 
-[Firmware]
-packages=firmware-atheros firmware-ralink firmware-realtek firmware-brcm80211 firmware-linux-free
+[Firmware_base]
+packages=firmware-linux-free
 source=http://mirrordirector.raspbian.org/raspbian
 keyring=debian-archive-keyring
 components=main non-free
+suite=jessie
+
+[Firmware_Foundation]
+packages=firmware-atheros firmware-ralink firmware-realtek firmware-brcm80211
+source=http://archive.raspberrypi.org/debian/
+keyring=debian-archive-keyring
+components=main
 suite=jessie

--- a/scripts/raspberryconfig.sh
+++ b/scripts/raspberryconfig.sh
@@ -102,13 +102,6 @@ echo "Adding support for dtoverlay=pi3-disable-wifi on 4.4.9 kernel"
 wget -P /boot/overlays/. https://github.com/Hexxeh/rpi-firmware/raw/$FIRMWARE_COMMIT/overlays/pi3-disable-wifi.dtbo
 fi
 
-echo "Adding PI3 & PiZero W Wireless firmware"
-wget http://repo.volumio.org/Volumio2/wireless-firmwares/brcmfmac43430-sdio.txt -P /lib/firmware/brcm/
-wget http://repo.volumio.org/Volumio2/wireless-firmwares/brcmfmac43430-sdio.bin -P /lib/firmware/brcm/
-
-echo "Adding PI WIFI Wireless dongle firmware"
-wget http://repo.volumio.org/Volumio2/wireless-firmwares/brcmfmac43143.bin -P /lib/firmware/brcm/
-
 #echo "Adding raspi-config"
 #wget -P /raspi http://archive.raspberrypi.org/debian/pool/main/r/raspi-config/raspi-config_20151019_all.deb
 #dpkg -i /raspi/raspi-config_20151019_all.deb


### PR DESCRIPTION
`firmware-atheros` `firmware-ralink` `firmware-realtek` `firmware-brcm80211` from Pi-Foundation (customized [`firmware-nonfree`](https://github.com/RPi-Distro/firmware-nonfree/blob/master/debian/control)) include brcmfmac43143, brcmfmac43430-sdio, ralink mt7601u firmware & others, that Raspian & Debian repo may not have.
`firmware-linux-free` remains from Raspbian baseline repo.

Replaces reverted https://github.com/volumio/Build/pull/211 and fixes https://github.com/volumio/Volumio2/issues/1080 on Pi

Checked built image contains the expected files accordingly.