### PR TITLE
Pi: fix mrEngman install script invocation

### DIFF
--- a/scripts/raspberryconfig.sh
+++ b/scripts/raspberryconfig.sh
@@ -218,48 +218,56 @@ cd wifi
 echo "WIFI: 8192EU for armv7"
 wget $MRENGMAN_REPO/8192eu-$KERNEL_VERSION-v7-$KERNEL_REV.tar.gz
 tar xf 8192eu-$KERNEL_VERSION-v7-$KERNEL_REV.tar.gz
+sed -i 's/^kernel=.*$/kernel='"$KERNEL_VERSION"'-v7+/' install.sh
 sh install.sh
 rm -rf *
 
 echo "WIFI: 8192EU for armv6"
 wget $MRENGMAN_REPO/8192eu-$KERNEL_VERSION-$KERNEL_REV.tar.gz
 tar xf 8192eu-$KERNEL_VERSION-$KERNEL_REV.tar.gz
+sed -i 's/^kernel=.*$/kernel='"$KERNEL_VERSION"'+/' install.sh
 sh install.sh
 rm -rf *
 
 echo "WIFI: 8812AU for armv7"
 wget $MRENGMAN_REPO/8812au-$KERNEL_VERSION-v7-$KERNEL_REV.tar.gz
 tar xf 8812au-$KERNEL_VERSION-v7-$KERNEL_REV.tar.gz
+sed -i 's/^kernel=.*$/kernel='"$KERNEL_VERSION"'-v7+/' install.sh
 sh install.sh
 rm -rf *
 
 echo "WIFI: 8812AU for armv6"
 wget $MRENGMAN_REPO/8812au-$KERNEL_VERSION-$KERNEL_REV.tar.gz
 tar xf 8812au-$KERNEL_VERSION-$KERNEL_REV.tar.gz
+sed -i 's/^kernel=.*$/kernel='"$KERNEL_VERSION"'+/' install.sh
 sh install.sh
 rm -rf *
 
 echo "WIFI: 8188EU for armv7"
 wget $MRENGMAN_REPO/8188eu-$KERNEL_VERSION-v7-$KERNEL_REV.tar.gz
 tar xf 8188eu-$KERNEL_VERSION-v7-$KERNEL_REV.tar.gz
+sed -i 's/^kernel=.*$/kernel='"$KERNEL_VERSION"'-v7+/' install.sh
 sh install.sh
 rm -rf *
 
 echo "WIFI: 8188EU for armv6"
 wget $MRENGMAN_REPO/8188eu-$KERNEL_VERSION-$KERNEL_REV.tar.gz
 tar xf 8188eu-$KERNEL_VERSION-$KERNEL_REV.tar.gz
+sed -i 's/^kernel=.*$/kernel='"$KERNEL_VERSION"'+/' install.sh
 sh install.sh
 rm -rf *
 
 echo "WIFI: MT7610 for armv7"
 wget $MRENGMAN_REPO/mt7610-$KERNEL_VERSION-v7-$KERNEL_REV.tar.gz
 tar xf mt7610-$KERNEL_VERSION-v7-$KERNEL_REV.tar.gz
+sed -i 's/^kernel=.*$/kernel='"$KERNEL_VERSION"'-v7+/' install.sh
 sh install.sh
 rm -rf *
 
 echo "WIFI: MT7610 for armv6"
 wget $MRENGMAN_REPO/mt7610-$KERNEL_VERSION-$KERNEL_REV.tar.gz
 tar xf mt7610-$KERNEL_VERSION-$KERNEL_REV.tar.gz
+sed -i 's/^kernel=.*$/kernel='"$KERNEL_VERSION"'+/' install.sh
 sh install.sh
 rm -rf *
 

--- a/scripts/raspberryconfig.sh
+++ b/scripts/raspberryconfig.sh
@@ -218,49 +218,49 @@ cd wifi
 echo "WIFI: 8192EU for armv7"
 wget $MRENGMAN_REPO/8192eu-$KERNEL_VERSION-v7-$KERNEL_REV.tar.gz
 tar xf 8192eu-$KERNEL_VERSION-v7-$KERNEL_REV.tar.gz
-./install.sh
+sh install.sh
 rm -rf *
 
 echo "WIFI: 8192EU for armv6"
 wget $MRENGMAN_REPO/8192eu-$KERNEL_VERSION-$KERNEL_REV.tar.gz
 tar xf 8192eu-$KERNEL_VERSION-$KERNEL_REV.tar.gz
-./install.sh
+sh install.sh
 rm -rf *
 
 echo "WIFI: 8812AU for armv7"
 wget $MRENGMAN_REPO/8812au-$KERNEL_VERSION-v7-$KERNEL_REV.tar.gz
 tar xf 8812au-$KERNEL_VERSION-v7-$KERNEL_REV.tar.gz
-./install.sh
+sh install.sh
 rm -rf *
 
 echo "WIFI: 8812AU for armv6"
 wget $MRENGMAN_REPO/8812au-$KERNEL_VERSION-$KERNEL_REV.tar.gz
 tar xf 8812au-$KERNEL_VERSION-$KERNEL_REV.tar.gz
-./install.sh
+sh install.sh
 rm -rf *
 
 echo "WIFI: 8188EU for armv7"
 wget $MRENGMAN_REPO/8188eu-$KERNEL_VERSION-v7-$KERNEL_REV.tar.gz
 tar xf 8188eu-$KERNEL_VERSION-v7-$KERNEL_REV.tar.gz
-./install.sh
+sh install.sh
 rm -rf *
 
 echo "WIFI: 8188EU for armv6"
 wget $MRENGMAN_REPO/8188eu-$KERNEL_VERSION-$KERNEL_REV.tar.gz
 tar xf 8188eu-$KERNEL_VERSION-$KERNEL_REV.tar.gz
-./install.sh
+sh install.sh
 rm -rf *
 
 echo "WIFI: MT7610 for armv7"
 wget $MRENGMAN_REPO/mt7610-$KERNEL_VERSION-v7-$KERNEL_REV.tar.gz
 tar xf mt7610-$KERNEL_VERSION-v7-$KERNEL_REV.tar.gz
-./install.sh
+sh install.sh
 rm -rf *
 
 echo "WIFI: MT7610 for armv6"
 wget $MRENGMAN_REPO/mt7610-$KERNEL_VERSION-$KERNEL_REV.tar.gz
 tar xf mt7610-$KERNEL_VERSION-$KERNEL_REV.tar.gz
-./install.sh
+sh install.sh
 rm -rf *
 
 cd ..


### PR DESCRIPTION
a closer look at Build log output shows `./install.sh` invocation issues command in host OS rather in qemu.
`sh install.sh` happens properly in wanted qemu environment
Checked ok with a new build.