### PR TITLE
Pi: use Pi-Foundation wireless firmware packages

### DIFF
--- a/scripts/raspberryconfig.sh
+++ b/scripts/raspberryconfig.sh
@@ -42,7 +42,6 @@ deb-src http://archive.raspberrypi.org/debian/ jessie main ui
 " >> /etc/apt/sources.list.d/raspi.list
 
 echo "Adding Raspberrypi.org Repo Key"
-
 wget http://archive.raspberrypi.org/debian/raspberrypi.gpg.key -O - | sudo apt-key add -
 
 echo "Installing R-pi specific binaries"
@@ -95,19 +94,15 @@ Pin: release *
 Pin-Priority: -1" > /etc/apt/preferences
 apt-mark hold raspberrypi-kernel raspberrypi-bootloader   #libraspberrypi0 depends on raspberrypi-bootloader
 
+echo "Adding PI3 & PiZero W Wireless, PI WIFI Wireless dongle, ralink mt7601u & few others firmware upgraging to Pi Foundations packages"
+apt-get install -y --only-upgrade firmware-atheros firmware-ralink firmware-realtek firmware-brcm80211
+
 if [ "$KERNEL_VERSION" = "4.4.9" ]; then       # probably won't be necessary in future kernels 
 echo "Adding initial support for PiZero W wireless on 4.4.9 kernel"
 wget -P /boot/. https://github.com/Hexxeh/rpi-firmware/raw/$FIRMWARE_COMMIT/bcm2708-rpi-0-w.dtb
 echo "Adding support for dtoverlay=pi3-disable-wifi on 4.4.9 kernel"
 wget -P /boot/overlays/. https://github.com/Hexxeh/rpi-firmware/raw/$FIRMWARE_COMMIT/overlays/pi3-disable-wifi.dtbo
 fi
-
-echo "Adding PI3 & PiZero W Wireless firmware"
-wget http://repo.volumio.org/Volumio2/wireless-firmwares/brcmfmac43430-sdio.txt -P /lib/firmware/brcm/
-wget http://repo.volumio.org/Volumio2/wireless-firmwares/brcmfmac43430-sdio.bin -P /lib/firmware/brcm/
-
-echo "Adding PI WIFI Wireless dongle firmware"
-wget http://repo.volumio.org/Volumio2/wireless-firmwares/brcmfmac43143.bin -P /lib/firmware/brcm/
 
 #echo "Adding raspi-config"
 #wget -P /raspi http://archive.raspberrypi.org/debian/pool/main/r/raspi-config/raspi-config_20151019_all.deb


### PR DESCRIPTION
`firmware-atheros` `firmware-ralink` `firmware-realtek` `firmware-brcm80211` packages from Pi-Foundation (customized [`firmware-nonfree`](https://github.com/RPi-Distro/firmware-nonfree/blob/master/debian/control)) include brcmfmac43143, brcmfmac43430-sdio, ralink mt7601u firmware & others, that Raspian & Debian repo may not have.
Replaces #213 and fixes volumio/Volumio2#1080 and https://github.com/volumio/Volumio2/issues/588 on Pi

Checked built image contains the expected files accordingly:
```
volumio@volumio:~$ ls /lib/firmware
RTL8192E       ath6k          mt7601u.bin  rt3090.bin
RTL8192SU      av7110         mt7610u.bin  rt3290.bin
allo           brcm           mt7650u.bin  rt73.bin
ar3k           carl9170-1.fw  rt2561.bin   rtl_nic
ar5523.bin     cis            rt2561s.bin  rtlwifi
ar7010.fw      dsp56k         rt2661.bin   usbdux_firmware.bin
ar7010_1_1.fw  htc_7010.fw    rt2860.bin   usbduxfast_firmware.bin
ar9170.fw      htc_9271.fw    rt2870.bin   usbduxsigma_firmware.bin
ar9271.fw      isci           rt3070.bin
ath3k-1.fw     keyspan_pda    rt3071.bin

volumio@volumio:~$ ls /lib/firmware/brcm
bcm43xx-0.fw              brcmfmac43241b4-sdio.bin  brcmfmac43362-sdio.bin
bcm43xx_hdr-0.fw          brcmfmac4329-sdio.bin     brcmfmac43430-sdio.bin
brcmfmac43143-sdio.bin    brcmfmac4330-sdio.bin     brcmfmac43430-sdio.txt
brcmfmac43143.bin         brcmfmac4334-sdio.bin     brcmfmac4354-sdio.bin
brcmfmac43241b0-sdio.bin  brcmfmac4335-sdio.bin
```