### PR TITLE
init script with boot device support

### DIFF
--- a/scripts/initramfs/init
+++ b/scripts/initramfs/init
@@ -155,15 +155,13 @@ mount -t ext4 ${IMGPART} /mnt/imgpart
 #create recovery image when not yet present
 #when already present and a bootdelay parameter was specified then give the kernel the additional headstart
 #
-
-
 if [ ! -e "/mnt/imgpart/volumio_factory.sqsh" ]; then
   print_msg "Creating factory image, this will take a minute, please wait..."
   cp /mnt/imgpart/volumio_current.sqsh /mnt/imgpart/volumio_factory.sqsh
   print_msg "Factory image created"
   print_msg "Creating archive for factory kernel..."
   mkdir /mnt/factory
-  mount -t vfat /dev/mmcblk0p1 /mnt/factory
+  mount -t vfat /dev/${BOOTDEV}p1 /mnt/factory
   tar cf /mnt/imgpart/kernel_current.tar -C /mnt/factory .
   cp /mnt/imgpart/kernel_current.tar /mnt/imgpart/kernel_factory.tar
   umount /mnt/factory
@@ -187,7 +185,7 @@ if [ -e /dev/sda1 ]; then
   if [ -e /mnt/usb/factory_reset ]; then
     print_msg "Factory Reset on USB"
     mkdir /mnt/factory
-    mount -t auto /dev/mmcblk0p1 /mnt/factory
+    mount -t auto /dev/${BOOTDEV}p1 /mnt/factory
     echo " " > /mnt/factory/factory_reset
     umount /mnt/factory
     rm -r /mnt/factory
@@ -219,10 +217,10 @@ VOLUMIO_VERSION="$(cat /mnt/static/etc/os-release | grep VOLUMIO_VERSION)"
 #if there is factory file then format data partition
 #
 mkdir /mnt/factory
-mount -t auto /dev/mmcblk0p1 /mnt/factory
+mount -t auto /dev/${BOOTDEV}p1 /mnt/factory
 if [ -e "/mnt/factory/factory_reset" ]; then
   print_msg "Executing factory reset"
-  mkfs.ext4 -F -E stride=2,stripe-width=1024 -b 4096 /dev/mmcblk0p3 -L volumio_data
+  mkfs.ext4 -F -E stride=2,stripe-width=1024 -b 4096 /dev/${BOOTDEV}p3 -L volumio_data
   print_msg "Factory reset executed: part I - User DATA Part"
   tar xf /mnt/imgpart/kernel_factory.tar -C /mnt/factory
   print_msg "Factory reset executed: part II - Kernel"
@@ -239,7 +237,7 @@ if [ -e "/mnt/factory/factory_reset" ]; then
 fi
 if [ -e "/mnt/factory/user_data" ]; then
   print_msg "Deleting User Data"
-  mkfs.ext4 -F -E stride=2,stripe-width=1024 -b 4096 /dev/mmcblk0p3 -L volumio_data
+  mkfs.ext4 -F -E stride=2,stripe-width=1024 -b 4096 /dev/${BOOTDEV}p3 -L volumio_data
   rm /mnt/factory/user_data
   print_msg "User Data successfully deleted "
 fi
@@ -249,7 +247,7 @@ rm -r /mnt/factory
 
 # if the update failed before completion
 mkdir boot
-mount -t vfat /dev/mmcblk0p1 /boot
+mount -t vfat /dev/${BOOTDEV}p1 /boot
 if [ -e "/boot/update_process" ]; then
 print_msg "Previous update attempt failed, restoring fallbacks"
   cp /mnt/imgpart/kernel_fallback.tar /mnt/imgpart/kernel_current.tar
@@ -279,15 +277,15 @@ print_msg "unpacking kernel"
 fi
 
 # if data partition needs to be resized
-mount -t auto /dev/mmcblk0p1 /boot
+mount -t auto /dev/${BOOTDEV}p1 /boot
 if [ -e "/boot/resize-volumio-datapart" ]; then
 print_msg "Re-sizing Volumio data partition"
-  END="$(parted -s /dev/mmcblk0 unit MB print free | grep Free | tail -1 | awk '{print $2}' | grep -o '[0-9]\+')"
-  parted -s /dev/mmcblk0 resizepart 3 ${END}
-  e2fsck -fy /dev/mmcblk0p3
-  resize2fs /dev/mmcblk0p3
+  END="$(parted -s /dev/${BOOTDEV} unit MB print free | grep Free | tail -1 | awk '{print $2}' | grep -o '[0-9]\+')"
+  parted -s /dev/${BOOTDEV} resizepart 3 ${END}
+  e2fsck -fy /dev/${BOOTDEV}p3
+  resize2fs /dev/${BOOTDEV}p3
   print_msg "Volumio data partition succesfully resized"
-  parted -s /dev/mmcblk0 unit MB print
+  parted -s /dev/${BOOTDEV} unit MB print
   rm /boot/resize-volumio-datapart
 fi
 
@@ -298,7 +296,7 @@ rm -rf /boot
 # 4) mount a filesystem for write access to the static image
 # unclear: memory size? -o size=1024M
 [ -d /mnt/ext ] || mkdir -m 777 /mnt/ext
-mount -t ext4 -o noatime /dev/mmcblk0p3 /mnt/ext
+mount -t ext4 -o noatime /dev/${BOOTDEV}p3 /mnt/ext
 
 [ -d /mnt/ext/dyn ] || mkdir -m 777 /mnt/ext/dyn
 [ -d /mnt/ext/union ] || mkdir -m 777 /mnt/ext/union

--- a/scripts/vszeroimage.sh
+++ b/scripts/vszeroimage.sh
@@ -15,7 +15,7 @@ while getopts ":d:v:p:" opt; do
 done
 
 BUILDDATE=$(date -I)
-IMG_FILE="Volumio${VERSION}-${BUILDDATE}-voltastreamer0.img"
+IMG_FILE="Volumio${VERSION}-${BUILDDATE}-voltastream0.img"
 
 if [ "$ARCH" = arm ]; then
   DISTRO="Raspbian"
@@ -53,7 +53,7 @@ mkfs -F -t ext4 -L volumio "${SYS_PART}"
 mkfs -F -t ext4 -L volumio_data "${DATA_PART}"
 sync
 
-echo "Preparing for the Voltastreamer Zero kernel/ platform files"
+echo "Preparing for the Voltastream Zero kernel/ platform files"
 if [ -d platform-pv ]
 then
 	echo "Platform folder already exists - keeping it"
@@ -62,7 +62,7 @@ then
 else
 	echo "Clone Polyvection files from repo"
 	git clone https://github.com/volumio/platform-pv.git platform-pv
-	echo "Unpack the Voltastreamer Zero platform files"
+	echo "Unpack the Voltastream Zero platform files"
 	cd platform-pv
 	tar xfJ vszero.tar.xz
 	cd ..
@@ -97,15 +97,15 @@ mount -t vfat "${BOOT_PART}" /mnt/volumio/rootfs/boot
 
 echo "Copying Volumio RootFs"
 cp -pdR build/$ARCH/root/* /mnt/volumio/rootfs
-echo "Copying Voltastreamer boot files"
+echo "Copying Voltastream0 boot files"
 cp -R platform-pv/vszero/boot/* /mnt/volumio/rootfs/boot/
 
-echo "Copying Voltastreamer modules and firmware"
+echo "Copying Voltastream0 modules and firmware"
 cp -pdR platform-pv/vszero/lib/modules /mnt/volumio/rootfs/lib/
 cp -pdR platform-pv/vszero/lib/firmware /mnt/volumio/rootfs/lib/
 sync
 
-echo "Preparing to run chroot for more Voltastreamer configuration"
+echo "Preparing to run chroot for more Voltastream0 configuration"
 cp scripts/vszeroconfig.sh /mnt/volumio/rootfs
 cp scripts/initramfs/init /mnt/volumio/rootfs/root
 cp scripts/initramfs/mkinitramfs-custom.sh /mnt/volumio/rootfs/usr/local/sbin
@@ -130,7 +130,7 @@ umount -l /mnt/volumio/rootfs/dev
 umount -l /mnt/volumio/rootfs/proc
 umount -l /mnt/volumio/rootfs/sys
 
-echo "==> Voltastreamer Zero device installed"
+echo "==> Voltastream Zero device installed"
 
 sync
 


### PR DESCRIPTION
init will default to mmcblk0 for the boot device.
On newer devices, the boot device can also be mmcblk1
This can be overruled on the boot command line with the "bootdev=" parameter.
like "bootdev=mmcblk1" (as used for for Rock64 and Voltastream0)