### PR TITLE
Avoid SMB1 protocol

### DIFF
--- a/volumio/etc/samba/smb.conf
+++ b/volumio/etc/samba/smb.conf
@@ -10,6 +10,7 @@ local master = no
 preferred master = no
 os level = 30
 client min protocol = smb2_02
+server min protocol = smb2_02
 
 [Internal Storage]
         comment = Volumio Internal Music Folder

--- a/volumio/etc/samba/smb.conf
+++ b/volumio/etc/samba/smb.conf
@@ -9,6 +9,7 @@ wins support = yes
 local master = no
 preferred master = no
 os level = 30
+client min protocol = smb2_02
 
 [Internal Storage]
         comment = Volumio Internal Music Folder


### PR DESCRIPTION
SMB1 is dangerous (e.g. WannaCry malware) and while still the default is best avoided.
smb2_02 is supported by Windows Vista and later, which should be a resonable choice.
smb2_10 (Win7 and later) might be better, what do people think?

This was requested in volumio/Volumio2#878. Not tested yet as I rarely use samba
and have never used the shares exposed by volumio.
Anyone who wants to jump in and test or comment, please do.