### PR TITLE
X86 Updater: separate the embedded grub config from the EFI bootloader

### DIFF
--- a/scripts/initramfs/init-x86
+++ b/scripts/initramfs/init-x86
@@ -326,10 +326,11 @@ if [ -e "/boot/kernel_update" ]; then
   mv /boot/syslinux.tmpl /boot/syslinux.cfg
   sed -i "s/%%IMGPART%%/${UUID_IMG}/g" /boot/syslinux.cfg
   sed -i "s/%%BOOTPART%%/${UUID_BOOT}/g" /boot/syslinux.cfg
-  mv /boot/grub/grub.cfg /boot/grub/grub.cfg.old
-  mv /boot/grub/grub.tmpl /boot/grub/grub.cfg
-  sed -i "s/root=imgpart=%%IMGPART%%/imgpart=UUID=${UUID_IMG}/g" /boot/grub/grub.cfg
-  sed -i "s/bootpart=%%BOOTPART%%/bootpart=UUID=${UUID_BOOT}/g" /boot/grub/grub.cfg
+  mv /boot/efi/BOOT/grub.cfg /boot/efi/BOOT/grub.cfg.old
+  mv /boot/efi/BOOT/grub.tmpl /boot/efi/BOOT/grub.cfg
+  sed -i "s/root=imgpart=%%IMGPART%%/imgpart=UUID=${UUID_IMG}/g" /boot/efi/BOOT/grub.cfg
+  sed -i "s/bootpart=%%BOOTPART%%/bootpart=UUID=${UUID_BOOT}/g" /boot/efi/BOOT/grub.cfg
+  sed -i "s/%%BOOTPART%%/${UUID_BOOT}/g" /boot/efi/BOOT/grub.cfg
   rm /boot/resize-volumio-datapart
   rm /boot/kernel_update
   sync

--- a/scripts/x86config.sh
+++ b/scripts/x86config.sh
@@ -29,10 +29,10 @@ echo "Installing Syslinux Legacy BIOS"
 syslinux -v
 syslinux "${BOOT_PART}"
 
-echo "  Getting the current kernel filename"
+echo "Getting the current kernel filename"
 KRNL=`ls -l /boot |grep vmlinuz | awk '{print $9}'`
 
-echo "  Creating run-time template for syslinux config"
+echo "Creating run-time template for syslinux config"
 echo "DEFAULT volumio
 
 LABEL volumio
@@ -47,8 +47,7 @@ cp /boot/syslinux.tmpl /boot/syslinux.cfg
 sed -i "s/%%IMGPART%%/${UUID_IMG}/g" /boot/syslinux.cfg
 sed -i "s/%%BOOTPART%%/${UUID_BOOT}/g" /boot/syslinux.cfg
 
-echo "Installing Grub UEFI"
-echo "  Editing the grub config template"
+echo "Editing the Grub UEFI config template"
 # Make grub boot menu transparent
 sed -i "s/menu_color_normal=cyan\/blue/menu_color_normal=white\/black/g" /etc/grub.d/05_debian_theme
 sed -i "s/menu_color_highlight=white\/blue/menu_color_highlight=green\/dark-gray/g" /etc/grub.d/05_debian_theme
@@ -61,34 +60,40 @@ sed -i "s/initrd=\"\$i\"/initrd=\"volumio.initrd\"/g" /etc/grub.d/10_linux
 sed -i "s/LINUX_ROOT_DEVICE=\${GRUB_DEVICE}/LINUX_ROOT_DEVICE=imgpart=%%IMGPART%% /g" /etc/grub.d/10_linux
 sed -i "s/LINUX_ROOT_DEVICE=UUID=\${GRUB_DEVICE_UUID}/LINUX_ROOT_DEVICE=imgpart=%%IMGPART%% /g" /etc/grub.d/10_linux
 
-echo "Setting grub image"
+echo "Setting plymouth image"
 cp /usr/share/plymouth/themes/volumio/volumio-logo16.png /boot/volumio.png
 
-echo "  Creating grub config folder"
-mkdir -p /boot/grub
+echo "Creating Grub config folder"
+mkdir /boot/grub
 
-echo "  Applying Grub Configuration"
+echo "Applying Grub configuration"
 grub-mkconfig -o /boot/grub/grub.cfg
-chmod +w boot/grub/grub.cfg
-echo "Use current grub.cfg as run-time template"
-cp /boot/grub/grub.cfg /boot/grub/grub.tmpl
-sed -i "s/${UUID_BOOT}/%%BOOTPART%%/g" /boot/grub/grub.tmpl
+chmod +w /boot/grub/grub.cfg
 
-echo "  Inserting root and boot partition label (building the boot cmdline used in initramfs)"
+echo "Coyping the new Grub config to the EFI bootloader folder"
+cp /boot/grub/grub.cfg /boot/efi/BOOT/grub.cfg
+
+echo "Telling the bootloader to read an external config" 
+echo 'configfile ${cmdpath}/grub.cfg' > /grub-redir.cfg
+
+echo "Using current grub.cfg as run-time template for kernel updates"
+cp /boot/efi/BOOT/grub.cfg /boot/efi/BOOT/grub.tmpl
+sed -i "s/${UUID_BOOT}/%%BOOTPART%%/g" /boot/efi/BOOT/grub.tmpl
+
+echo "Inserting root and boot partition UUIDs (building the boot cmdline used in initramfs)"
 # Opting for finding partitions by-UUID
-sed -i "s/root=imgpart=%%IMGPART%%/imgpart=UUID=${UUID_IMG}/g" /boot/grub/grub.cfg
-sed -i "s/bootpart=%%BOOTPART%%/bootpart=UUID=${UUID_BOOT}/g" /boot/grub/grub.cfg
+sed -i "s/root=imgpart=%%IMGPART%%/imgpart=UUID=${UUID_IMG}/g" /boot/efi/BOOT/grub.cfg
+sed -i "s/bootpart=%%BOOTPART%%/bootpart=UUID=${UUID_BOOT}/g" /boot/efi/BOOT/grub.cfg
 
-echo "  Prevent cgmanager starting during install (causing problems)"
 cat > /usr/sbin/policy-rc.d << EOF
 exit 101
 EOF
 chmod +x /usr/sbin/policy-rc.d
 
-echo "  Installing grub-efi-amd64 to make the 64bit UEFI bootloader"
+echo "Installing grub-efi-amd64 to make the 64bit UEFI bootloader"
 apt-get update
 apt-get -y install grub-efi-amd64-bin
-grub-mkstandalone --compress=gz -O x86_64-efi -o /boot/efi/BOOT/BOOTX64.EFI -d /usr/lib/grub/x86_64-efi --modules="part_gpt part_msdos" --fonts="unicode" --themes="" /boot/grub/grub.cfg
+grub-mkstandalone --compress=gz -O x86_64-efi -o /boot/efi/BOOT/BOOTX64.EFI "boot/grub/grub.cfg=grub-redir.cfg" -d /usr/lib/grub/x86_64-efi --modules="part_gpt part_msdos" --fonts="unicode" --themes=""
 if [ ! -e /boot/efi/BOOT/BOOTX64.EFI ]; then
 	echo "Fatal error, no 64bit bootmanager created, aborting..." 
     exit 1
@@ -96,20 +101,22 @@ fi
 
 #we cannot install grub-efi-amd64 and grub-efi-ia32 on the same machine.
 #on the off-chance that we need a 32bit bootloader, we remove amd64 and install ia32 to generate one
-echo "  Uninstalling grub-efi-amd64"
+echo "Uninstalling grub-efi-amd64"
 apt-get -y --purge remove grub-efi-amd64-bin
 
-echo "  Installing grub-efi-ia32 to make the 32bit UEFI bootloader"
+echo "Installing grub-efi-ia32 to make the 32bit UEFI bootloader"
 apt-get -y install grub-efi-ia32-bin
-grub-mkstandalone --compress=gz -O i386-efi -o /boot/efi/BOOT/BOOTIA32.EFI -d /usr/lib/grub/i386-efi --modules="part_gpt part_msdos" --fonts="unicode" --themes="" /boot/grub/grub.cfg 
+grub-mkstandalone --compress=gz -O i386-efi -o /boot/efi/BOOT/BOOTIA32.EFI "boot/grub/grub.cfg=grub-redir.cfg" -d /usr/lib/grub/i386-efi --modules="part_gpt part_msdos" --fonts="unicode" --themes="" 
 if [ ! -e /boot/efi/BOOT/BOOTIA32.EFI ]; then
 	echo "Fatal error, no 32bit bootmanager created, aborting..." 
     exit 1
 fi
 #and remove it again
-echo "  Uninstalling grub-efi-ia32-bin"
+echo "Uninstalling grub-efi-ia32-bin and cleaning up grub install"
 apt-get -y --purge remove grub-efi-ia32-bin
 apt-get -y --purge remove efibootmgr libefivar0
+rm /grub-redir.cfg
+rm -r /boot/grub
 
 echo "Cleaning APT Cache and remove policy file"
 rm -f /var/lib/apt/lists/*archive*
@@ -130,7 +137,7 @@ apt-get -y install plymouth plymouth-themes plymouth-x11
 plymouth-set-default-theme volumio
 
 echo "Setting up in kiosk-mode"
-echo "  Creating chromium kiosk start script"
+echo "Creating chromium kiosk start script"
 echo "#!/bin/bash
 
 xset -dpms
@@ -161,11 +168,11 @@ WantedBy=multi-user.target
 " > /lib/systemd/system/volumio-kiosk.service
 ln -s /lib/systemd/system/volumio-kiosk.service /etc/systemd/system/multi-user.target.wants/volumio-kiosk.service
 
-echo "  Allowing volumio to start an xsession"
+echo "Allowing volumio to start an xsession"
 sed -i "s/allowed_users=console/allowed_users=anybody/" /etc/X11/Xwrapper.config
 
 echo "Creating initramfs"
-echo "  Adding custom modules"
+echo "Adding custom modules"
 echo "overlay" >> /etc/initramfs-tools/modules
 echo "squashfs" >> /etc/initramfs-tools/modules
 echo "usbcore" >> /etc/initramfs-tools/modules
@@ -187,27 +194,27 @@ echo "hid" >> /etc/initramfs-tools/modules
 echo "nls_cp437" >> /etc/initramfs-tools/modules
 echo "nls_utf8" >> /etc/initramfs-tools/modules
 echo "vfat" >> /etc/initramfs-tools/modules
-echo "  Adding ata modules for various chipsets"
+echo "Adding ata modules for various chipsets"
 cat /ata-modules.x86 >> /etc/initramfs-tools/modules
-echo "  Adding modules for Plymouth"
+echo "Adding modules for Plymouth"
 echo "intel_agp" >> /etc/initramfs-tools/modules
 echo "drm" >> /etc/initramfs-tools/modules
 echo "i915 modeset=1" >> /etc/initramfs-tools/modules
 
-echo "  Copying volumio initramfs updater"
+echo "Copying volumio initramfs updater"
 cd /root/
 mv volumio-init-updater /usr/local/sbin
 
-echo "  Creating initramfs 'volumio.initrd'"
+echo "Creating initramfs 'volumio.initrd'"
 mkinitramfs-custom.sh -o /tmp/initramfs-tmp
 
-echo "  No need to keep the original initrd"
+echo "No need to keep the original initrd"
 DELFILE=`ls -l /boot |grep initrd.img | awk '{print $9}'`
-echo "  Found "$DELFILE", deleting"
+echo "Found "$DELFILE", deleting"
 rm /boot/${DELFILE}
-echo "  No need for the system map either"
+echo "No need for the system map either"
 DELFILE=`ls -l /boot |grep System.map | awk '{print $9}'`
-echo "  Found "$DELFILE", deleting"
+echo "Found "$DELFILE", deleting"
 rm /boot/${DELFILE}
 
 #On The Fly Patch
@@ -229,7 +236,7 @@ rm -rf ${PATCH}
 fi
 rm /patch
 
-echo "  Signalling the init script to re-size the volumio data partition"
+echo "Signalling the init script to re-size the volumio data partition"
 touch /boot/resize-volumio-datapart
 
 echo "Bootloader configuration and initrd.img complete"


### PR DESCRIPTION
Error: editing the /boot/grub/grub.cfg when updating the kernel in initramsfs has no effect as the grub configuration has been built into the standalone EFI bootloader(s).
For the X86 kernel updater to work, we need to remove the embedded grub config from the EFI bootloader(s) and place it into the EFI folder. This will allow editing in initrd.