### PR TITLE
Pi: move to Kernel 4.9.41

### DIFF
--- a/scripts/raspberryconfig.sh
+++ b/scripts/raspberryconfig.sh
@@ -56,7 +56,7 @@ sudo curl -L --output /usr/bin/rpi-update https://raw.githubusercontent.com/Hexx
 touch /boot/start.elf
 mkdir /lib/modules
 
-KERNEL_VERSION="4.9.36"
+KERNEL_VERSION="4.9.41"
 
 case $KERNEL_VERSION in
     "4.4.9")
@@ -64,9 +64,9 @@ case $KERNEL_VERSION in
       KERNEL_COMMIT="15ffab5493d74b12194e6bfc5bbb1c0f71140155"
       FIRMWARE_COMMIT="9108b7f712f78cbefe45891bfa852d9347989529"
       ;; 
-    "4.9.36")
-      KERNEL_REV="1015"
-      KERNEL_COMMIT="400f6d196503e50b87025b888169f30214bc0f19"
+    "4.9.41")
+      KERNEL_REV="1023"
+      KERNEL_COMMIT="b9becbbf3f48e39f719ca6785d23c53ee0cdbe49"
       FIRMWARE_COMMIT=$KERNEL_COMMIT
       ;; 
 esac


### PR DESCRIPTION
Several improvements, including better support for several i2s DACs (allo, etc).
Has been also pushed as new "stable" reference branch