### PR TITLE
X86: Fixing a usb3.0 boot issue and improving plymouth support

### DIFF
--- a/scripts/initramfs/init-x86
+++ b/scripts/initramfs/init-x86
@@ -56,13 +56,14 @@ modprobe nls_cp437
 modprobe nls_utf8
 modprobe usb_common
 modprobe usbcore
-# The EHCI driver should be loaded before the ones for low speed cpntrollers
-# or some devices may be confused when they are disconencted and reconnected.
+# The EHCI driver should be loaded before the ones for low speed controllers
+# or some devices may be confused when they are disconnected and reconnected.
 modprobe ehci_hcd
 modprobe ehci_pci
 modprobe uhci_hcd
 modprobe ohci_hcd
 modprobe ohci_pci
+modprobe xhci_hcd
 modprobe xhci_pci
 modprobe mmc_core
 modprobe sdhci
@@ -102,6 +103,14 @@ modprobe ata_generic
 print_msg "Waiting for storage devices to become ready"
 sleep 5
 mdev -s
+
+print_msg "Show plymouth with volumio theme"
+echo "[Daemon]
+Theme=volumio
+ShowDelay=0
+" > /usr/share/plymouth/plymouthd.defaults
+# No need to start plymouth daemon (started already), just show splash
+/bin/plymouth --show-splash
 
 # Parse the kernel command line from grub
 CMDLINE="$(cat /proc/cmdline)"
@@ -153,6 +162,9 @@ if [ -z "${IMGFILE}" ]; then
   exec sh
   exit 0
 fi
+
+# set a default for kmsg
+USE_KMSG=yes
 
 print_msg IMGPART=${IMGPART}
 print_msg IMGFILE=${IMGFILE}
@@ -349,11 +361,11 @@ print_msg "Checking for data partition re-size"
 if [ -e "/boot/resize-volumio-datapart" ]; then
   print_msg "Re-sizing Volumio data partition..."
   END="$(parted -s ${BOOT_DEVICE} unit MB print free | grep Free | tail -1 | awk '{print $2}' | grep -o '[0-9]\+')"
-  parted -s ${BOOT_DEVICE} resizepart 3 ${END}
+  parted -s ${BOOT_DEVICE} resizepart 3 ${END} > /boot/resize-datapart.log
   e2fsck -f ${BOOT_DEVICE}3
-  resize2fs ${BOOT_DEVICE}3
+  resize2fs ${BOOT_DEVICE}3 > /boot/resize-datapart.log
   print_msg "Volumio data partition succesfully resized"
-  parted -s ${BOOT_DEVICE} unit MB print
+  parted -s ${BOOT_DEVICE} unit MB print > /boot/resize-datapart.log
   rm /boot/resize-volumio-datapart
 fi
 umount /boot
@@ -414,6 +426,8 @@ print_msg ${VOLUMIO_VERSION}
 print_msg "Finishing initramfs, switching rootfs and starting the boot process..."
 umount /proc
 umount /sys
+
+/bin/plymouth --newroot=/mnt/ext/union
 
 exec switch_root /mnt/ext/union /sbin/init
 

--- a/scripts/x86config.sh
+++ b/scripts/x86config.sh
@@ -11,10 +11,6 @@ echo "Installing the kernel and creating initramfs"
 dpkg -i linux-image-*_i386.deb
 dpkg -i linux-firmware-*_i386.deb
 
-KRNL=`ls -l /boot |grep vmlinuz | awk -F'vmlinuz-' '{print $2}'`
-cp e1000e.ko /lib/modules/$KRNL/kernel/drivers/net/ethernet/intel/e1000e/
-depmod $KRNL
-
 echo "Creating node/ nodejs symlinks to stay compatible with the armv6/v7 platforms"
 ln -s /usr/bin/nodejs /usr/local/bin/nodejs
 
@@ -33,12 +29,13 @@ echo "Getting the current kernel filename"
 KRNL=`ls -l /boot |grep vmlinuz | awk '{print $9}'`
 
 echo "Creating run-time template for syslinux config"
+DEBUG="USE_KMSG=no"
 echo "DEFAULT volumio
 
 LABEL volumio
   SAY Legacy Boot Volumio Audiophile Music Player (default)
   LINUX ${KRNL}
-  APPEND ro imgpart=UUID=%%IMGPART%% bootpart=UUID=%%BOOTPART%% imgfile=volumio_current.sqsh quiet splash plymouth.ignore-serial-consoles vt.global_cursor_default=0 loglevel=0 ${DEBUG}
+  APPEND ro vga=792 imgpart=UUID=%%IMGPART%% bootpart=UUID=%%BOOTPART%% imgfile=volumio_current.sqsh quiet splash plymouth.ignore-serial-consoles vt.global_cursor_default=0 loglevel=0 ${DEBUG}
   INITRD volumio.initrd
 " > /boot/syslinux.tmpl
 
@@ -135,6 +132,10 @@ apt-get -y install fonts-arphic-ukai fonts-arphic-gbsn00lp fonts-unfonts-core
 echo "Configuring boot splash"
 apt-get -y install plymouth plymouth-themes plymouth-x11
 plymouth-set-default-theme volumio
+echo "[Daemon]
+Theme=volumio
+ShowDelay=0
+" > /usr/share/plymouth/plymouthd.defaults
 
 echo "Setting up in kiosk-mode"
 echo "Creating chromium kiosk start script"
@@ -200,6 +201,8 @@ echo "Adding modules for Plymouth"
 echo "intel_agp" >> /etc/initramfs-tools/modules
 echo "drm" >> /etc/initramfs-tools/modules
 echo "i915 modeset=1" >> /etc/initramfs-tools/modules
+echo "nouveau modeset=1" >> /etc/initramfs-tools/modules
+echo "radeon modeset=1" >> /etc/initramfs-tools/modules
 
 echo "Copying volumio initramfs updater"
 cd /root/

--- a/scripts/x86image.sh
+++ b/scripts/x86image.sh
@@ -91,7 +91,6 @@ else
   cp platform-x86/packages/linux-image-*.deb /mnt/volumio/rootfs
   cp platform-x86/packages/linux-firmware-*.deb /mnt/volumio/rootfs
 fi
-#cp platform-x86/Intel-e1000e-3.3.4/e1000e.ko /mnt/volumio/rootfs
 
 cp volumio/splash/volumio.png /mnt/volumio/rootfs/boot
 
@@ -128,7 +127,6 @@ chroot /mnt/volumio/rootfs /bin/bash -x <<'EOF'
 EOF
 
 rm /mnt/volumio/rootfs/init.sh /mnt/volumio/rootfs/linux-image-*.deb
-rm /mnt/volumio/rootfs/linux-firmware-*.deb /mnt/volumio/rootfs/e1000e.ko
 rm /mnt/volumio/rootfs/root/init /mnt/volumio/rootfs/x86config.sh
 rm /mnt/volumio/rootfs/ata-modules.x86
 sync


### PR DESCRIPTION
Plymouth is sort of working, at least consistently during boot. There are still issues with the splash resolution. Using legacy boot (syslinux) it seems to work ok and the image scales. With uefi (grub2) it also works, but sticks to 1024x768, making it look a little odd, half way up and to the left of a full HD screen. 
No idea yet why, any input welcome....