### PR TITLE
Typo generated in /boot/config.txt

### DIFF
--- a/scripts/initramfs/init
+++ b/scripts/initramfs/init
@@ -273,7 +273,7 @@ print_msg "unpacking kernel"
   if [ -e "/mnt/imgpart/config.txt.bak" ]; then
     print_msg "Restoring custom config.txt content"
     I2S=`sed -n -e '/#### Volumio i2s setting below: do not alter ####/,$p' /mnt/imgpart/config.txt.bak`
-    echo "\n" >> /boot/config.txt
+    echo "" >> /boot/config.txt
     echo "$I2S" >> /boot/config.txt
     rm /mnt/imgpart/config.txt.bak
   fi


### PR DESCRIPTION
Incidentally noticed in [this forum message](https://volumio.org/forum/flac-files-play-too-fast-after-latest-update-t7596.html#p38274) seemingly after a kernel update.
linefeed is generated by simple `echo ""` (at least on busybox echo)