### PR TITLE
Improve dynamicswap service definition

### DIFF
--- a/volumio/lib/systemd/system/dynamicswap.service
+++ b/volumio/lib/systemd/system/dynamicswap.service
@@ -1,3 +1,11 @@
+[Unit]
+Description = dynamicswap service
+DefaultDependencies=false
+
+Before=swap.target umount.target
+Conflicts=umount.target
+Wants=swap.target
+
 [Service]
 ExecStart=/bin/dynswap.sh
 StandardOutput=syslog


### PR DESCRIPTION
Have unit consistent with swap requirements as per [freedesktop.org reference](https://www.freedesktop.org/software/systemd/man/systemd.swap.html#Default%20Dependencies).

Is cleaner for proper reboot & shutdown.
(also similar to what [LibreELEC does](https://github.com/LibreELEC/LibreELEC.tv/blob/master/packages/sysutils/util-linux/system.d/swap.service))

Tested ok on PiZero