### PR TITLE
Rock64: Inital version

### DIFF
--- a/scripts/initramfs/init.nextarm
+++ b/scripts/initramfs/init.nextarm
@@ -1,0 +1,380 @@
+#!/bin/busybox sh
+
+# Default PATH differs between shells, and is not automatically exported
+# by klibc dash.  Make it consistent.
+export PATH=/sbin:/usr/sbin:/bin:/usr/bin
+
+[ -d /proc ] || mkdir /proc
+mount -t proc none /proc
+[ -d /sys ] || mkdir /sys
+mount -t sysfs none /sys
+
+mknod /dev/null c 1 3
+mknod /dev/tty c 5 0
+[ -e /dev/console ] || mknod /dev/console c 5 1
+
+mdev -s
+
+#Defaults which may be overridden by cmdline parameters
+USE_KMSG="yes"
+HWDEVICE="empty"
+BOOTDEV="mmcblk0"
+#Device/Partition Separator i.e. the character between parentdev and partition index
+DPS="p"
+#default values:
+IMGPART="/dev/${BOOTDEV}${DPS}2"
+DATAPART="/dev/${BOOTDEV}${DPS}3"
+BOOTPART="/dev/${BOOTDEV}${DPS}1"
+
+# Display a message or print directly to /dev/kmsg
+print_msg() {
+if [ $USE_KMSG == yes ]; then
+  echo "initramfs:" $1 >> /dev/kmsg
+else
+  echo "initramfs:" $1
+fi
+}
+
+# Parse the kernel command line
+
+CMDLINE="$(cat /proc/cmdline)"
+
+parse_disk() {
+  if [ "$(echo $1|cut -c -5)" = "UUID=" ]; then
+    # $1 is a UUID
+    echo $(findfs $1)
+  elif [ "$(echo $1|cut -c -6)" = "LABEL=" ]; then
+    # $1 is a LABEL
+    echo $(findfs $1)
+  elif [ "$(echo $1|cut -c -5)" = "/dev/" ]; then
+    # $1 is a device name
+    echo $1
+  else
+    # $1 is unrecognized.
+    echo "unknown-disk"
+  fi
+}
+
+DO_GEN=no
+
+for p in ${CMDLINE};
+do
+  key=${p%%=*}
+  value=${p#*=}
+  case $key in
+  imgpart)
+    IMGPART=`parse_disk $value`
+    ;;
+  imgfile)
+    IMGFILE=$value
+    ;;
+  bootdelay)
+    BOOTDELAY=$value
+    ;;
+  use_kmsg)
+    USE_KMSG=$value
+    ;;
+  bootdev)
+    BOOTDEV=$value
+    ;;
+  dps)
+    DPS=$value
+    ;;
+  genpnames)
+    DO_GEN=yes
+    ;;
+  bootpart)
+    BOOTPART=`parse_disk $value`
+    ;;
+  datapart)
+    DATAPART=`parse_disk $value`
+    ;;
+  hwdevice)
+    HWDEVICE=$value
+    ;;
+  esac
+done
+
+if [ $DO_GEN == yes ]; then
+    print_msg "re-generating partition names..."
+    IMGPART="/dev/${BOOTDEV}${DPS}2"
+    DATAPART="/dev/${BOOTDEV}${DPS}3"
+    BOOTPART="/dev/${BOOTDEV}${DPS}1"
+fi
+#Hardware specific adaptions
+
+#When we did not already get the device name from the cmdline, try getting it from cpuinfo
+if [ $HWDEVICE == empty ]; then
+  HWDEVICE="$(cat /proc/cpuinfo | grep Hardware | awk '{print $3}' )"
+fi
+
+if [ $HWDEVICE == ODROID-C2 ]; then
+   exec >/dev/kmsg 2>&1 </dev/console
+fi
+
+# Odroid C1, SparkySBC, Banana PI, Pine64 and Cubox have overlayfs version < V22
+if [ $HWDEVICE == ODROIDC ] || [ $HWDEVICE == gs705a ] || [ $HWDEVICE == sun50iw1p1 ] || [ $HWDEVICE == sun8iw11p1 ] || [ $HWDEVICE == Freescale ]; then
+   OVERLAY=NOWRKDIR
+   exec >/dev/kmsg 2>&1 </dev/console
+else
+   OVERLAY=WITHWRKDIR
+fi
+
+print_msg "Booting Volumio for ${HWDEVICE}"
+print_msg "	This script mounts rootfs RO with an overlay RW layer."
+if [ $OVERLAY == WITHWRKDIR ]; then
+   # For overlayfs version V22 or higher (modulename 'overlay')
+   modprobe overlay
+else
+   # For overlayfs version V20/V21 (modulename ='overlayfs')
+   modprobe overlayfs
+fi
+modprobe squashfs
+modprobe nls_cp437
+
+if [ -z "${IMGPART}" ]; then
+  print_msg "Specify the squash image partition after the kernel command ${CMDLINE}"
+  print_msg "example: kernel... imgpart=/dev/sda2 imgfile=/gentoo.sqs"
+  exec sh
+  exit 0
+fi
+
+if [ -z "${IMGFILE}" ]; then
+  print_msg "Specify the squash image file after the kernel command ${CMDLINE}"
+  print_msg "example: kernel... imgpart=/dev/sda2 imgfile=/gentoo.sqs"
+  exec sh
+  exit 0
+fi
+
+print_msg IMGPART=${IMGPART}
+print_msg IMGFILE=${IMGFILE}
+print_msg DATAPART=${DATAPART}
+print_msg BOOTPART=${BOOTPART}
+
+if [ ! -z "${BOOTDELAY}" ]; then
+  print_msg "Boot delay (except first time) will be ${BOOTDELAY} seconds"
+fi
+
+# Retry mdev -s 3 times before throwing the towel
+for i in 1 2 3 4 5 6
+  do
+    if [ ! -b "${IMGPART}" ]; then
+      print_msg  "${IMGPART} not detected,retrying mdev in 5 seconds"
+	  sleep 0.5
+      mdev -s
+    else
+	  print_msg `blkid ${IMGPART}`
+      break
+    fi
+  done
+
+if [ ! -b "${IMGPART}" ]; then
+  print_msg "No partition with ${IMGPART} has been found"
+  exec sh
+  exit 0
+fi
+
+# ok, parsing done
+[ -d /mnt ] || mkdir /mnt
+# Mount the partitions
+# 1) mount the partition where the squash image resides
+[ -d /mnt/imgpart ] || mkdir /mnt/imgpart
+mount -t ext4 ${IMGPART} /mnt/imgpart
+
+#create recovery image when not yet present
+#when already present and a bootdelay parameter was specified then give the kernel the additional headstart
+#
+if [ ! -e "/mnt/imgpart/volumio_factory.sqsh" ]; then
+  print_msg "Creating factory image, this will take a minute, please wait..."
+  cp /mnt/imgpart/volumio_current.sqsh /mnt/imgpart/volumio_factory.sqsh
+  print_msg "Factory image created"
+  print_msg "Creating archive for factory kernel..."
+  mkdir /mnt/factory
+  mount -t vfat ${BOOTPART} /mnt/factory
+  tar cf /mnt/imgpart/kernel_current.tar -C /mnt/factory .
+  cp /mnt/imgpart/kernel_current.tar /mnt/imgpart/kernel_factory.tar
+  umount /mnt/factory
+  rm -r /mnt/factory
+elif [ ! -z "${BOOTDELAY}" ]; then
+  print_msg "Doing a ${BOOTDELAY} second delay here to give kernel load a headstart"
+  sleep ${BOOTDELAY}
+fi
+
+print_msg "Checking for USB updates if you did not boot from USB..."
+[ -e /dev/sda1 ] || mdev -s
+if [ -e /dev/sda1 ] && [ ! "/dev/sda1" ==  "${BOOTPART}" ]; then
+  [ -d /mnt/usb ] || mkdir /mnt/usb
+  mount -t auto /dev/sda1 /mnt/usb
+  #If there is a firmware file inside the usb
+  if [ -e /mnt/usb/*.fir ]; then
+    print_msg "Firmware found, updating will take a few minutes, please wait..."
+    mkdir /mnt/boot
+    mount -t auto ${BOOTPART} /mnt/boot
+    #when the partitions are mounted we can launch the update script
+    volumio-init-updater
+    sync
+    print_msg "USB Update applied"
+    umount /mnt/boot
+    rm -r /mnt/boot
+    print_msg "Restarting"
+    echo b > /proc/sysrq-trigger
+  fi
+  if [ -e /mnt/usb/factory_reset ]; then
+    print_msg "Factory Reset on USB"
+    mkdir /mnt/factory
+    mount -t auto ${BOOTPART} /mnt/factory
+    echo " " > /mnt/factory/factory_reset
+    umount /mnt/factory
+    rm -r /mnt/factory
+    rm /mnt/usb/factory_reset
+  fi
+  umount /dev/sda1
+  rm -r /mnt/usb
+else
+  if [ "/dev/sda1" == "${BOOTPART}" ]; then
+    print_msg "Not checking for firmware if you boot from USB. Sorry!"
+  else 
+    print_msg "No USB device detected (when incorrect, try adding 'bootdelay=5' to your boot cmdline)"
+  fi
+fi
+
+
+# 2) init a loop pointing to the image file
+loop_free=$(losetup -f | sed s#p/#p#)
+if [ ! -e ${loop_free} ]; then
+  print_msg "Device node does not exist, creating it..."
+  # use last char from loop_device as minor device number
+  minor=$(echo ${loop_free} | sed 's/.*\(.\)/\1/')
+  mknod $loop_free b 7 $minor
+fi
+losetup $loop_free /mnt/imgpart/${IMGFILE}
+
+# 3) mount the squashfs to /mnt/static
+[ -d /mnt/static ] || mkdir /mnt/static
+mount -t squashfs $loop_free /mnt/static
+
+VOLUMIO_VERSION="$(cat /mnt/static/etc/os-release | grep VOLUMIO_VERSION)"
+
+#if there is factory file then format data partition
+#
+mkdir /mnt/factory
+mount -t auto ${BOOTPART} /mnt/factory
+if [ -e "/mnt/factory/factory_reset" ]; then
+  print_msg "Executing factory reset"
+  mkfs.ext4 -F -E stride=2,stripe-width=1024 -b 4096 ${DATAPART} -L volumio_data
+  print_msg "Factory reset executed: part I - User DATA Part"
+  tar xf /mnt/imgpart/kernel_factory.tar -C /mnt/factory
+  print_msg "Factory reset executed: part II - Kernel"
+  cp  /mnt/imgpart/volumio_factory.sqsh /mnt/imgpart/volumio_current.sqsh
+  print_msg "Factory reset executed: part III - Squash"
+  print_msg "Factory reset successfully executed"
+  sync
+  rm /mnt/factory/factory_reset
+
+  umount /mnt/factory
+  rm -r /mnt/factory
+  print_msg "Restarting"
+  echo b > /proc/sysrq-trigger
+fi
+if [ -e "/mnt/factory/user_data" ]; then
+  print_msg "Deleting User Data"
+  mkfs.ext4 -F -E stride=2,stripe-width=1024 -b 4096 ${DATAPART} -L volumio_data
+  rm /mnt/factory/user_data
+  print_msg "User Data successfully deleted "
+fi
+umount /mnt/factory
+rm -r /mnt/factory
+
+
+# if the update failed before completion
+mkdir boot
+mount -t vfat ${BOOTPART} /boot
+if [ -e "/boot/update_process" ]; then
+print_msg "Previous update attempt failed, restoring fallbacks"
+  cp /mnt/imgpart/kernel_fallback.tar /mnt/imgpart/kernel_current.tar
+  cp /mnt/imgpart/volumio_fallback.tar /mnt/imgpart/volumio_current.tar
+  if [-e "/boot/kernel_update" ]; then
+    rm /boot/kernel_update
+  fi
+  rm /boot/update_process
+fi
+
+# if the kernel has been updated, and no error has occurred before completition
+if [ -e "/boot/kernel_update" ]; then
+print_msg "unpacking kernel"
+  tar xf /mnt/imgpart/kernel_current.tar -C /boot
+  if [ -e "/mnt/imgpart/config.txt.bak" ]; then
+    print_msg "Restoring custom config.txt content"
+    I2S=`sed -n -e '/#### Volumio i2s setting below: do not alter ####/,$p' /mnt/imgpart/config.txt.bak`
+    echo "\n" >> /boot/config.txt
+    echo "$I2S" >> /boot/config.txt
+    rm /mnt/imgpart/config.txt.bak
+  fi
+  rm /boot/kernel_update
+  sync
+  umount /boot
+  rm -rf /boot
+  echo b > /proc/sysrq-trigger
+fi
+
+# if data partition needs to be resized
+#mount -t auto /dev/${BOOTDEV}p1 /boot
+if [ -e "/boot/resize-volumio-datapart" ]; then
+print_msg "Re-sizing Volumio data partition"
+  END="$(parted -s /dev/${BOOTDEV} unit MB print free | grep Free | tail -1 | awk '{print $2}' | grep -o '[0-9]\+')"
+  parted -s /dev/${BOOTDEV} resizepart 3 ${END}
+  e2fsck -fy ${DATAPART}
+  #force resize as we did just run e2fsck. Resize2fs seems ro not detect this occasionally
+  resize2fs -f ${DATAPART}
+  print_msg "Volumio data partition succesfully resized"
+  parted -s /dev/${BOOTDEV} unit MB print
+  rm /boot/resize-volumio-datapart
+fi
+
+# clear the mountpoint
+umount /boot
+rm -rf /boot
+
+# 4) mount a filesystem for write access to the static image
+# unclear: memory size? -o size=1024M
+[ -d /mnt/ext ] || mkdir -m 777 /mnt/ext
+mount -t ext4 -o noatime ${DATAPART} /mnt/ext
+
+[ -d /mnt/ext/dyn ] || mkdir -m 777 /mnt/ext/dyn
+[ -d /mnt/ext/union ] || mkdir -m 777 /mnt/ext/union
+
+# 5) mount the writable overlay to the static image
+if [ $OVERLAY == WITHWRKDIR ]; then
+  [ -d /mnt/ext/work ] || mkdir -m 777 /mnt/ext/work
+  print_msg "With Option:" $OVERLAY
+  mount -t overlay -olowerdir=/mnt/static,upperdir=/mnt/ext/dyn,workdir=/mnt/ext/work overlay /mnt/ext/union 
+else
+  print_msg "Without Option:" $OVERLAY
+  mount -t overlayfs overlayfs /mnt/ext/union -olowerdir=/mnt/static,upperdir=/mnt/ext/dyn
+fi
+
+[ -d /mnt/ext/union/static ] || mkdir -m 777 /mnt/ext/union/static
+[ -d /mnt/ext/union/imgpart ] || mkdir -m 777 /mnt/ext/union/imgpart
+mount --move /mnt/static /mnt/ext/union/static
+mount --move /mnt/imgpart /mnt/ext/union/imgpart
+
+chmod -R 777 /mnt/ext/union/imgpart
+
+#idea: Mount /boot already here to that systemd does not have to mount it an we
+# can be flexible. However this should be confirmed by somebody who is more familiar 
+# with systemd and who can tell what fstab is used for in the system
+
+[ -d /mnt/ext/union/boot ] || mkdir -m 777 /mnt/ext/union/boot
+mount -t vfat -o defaults,utf8,user,rw,umask=111,dmask=000 ${BOOTPART} /mnt/ext/union/boot
+
+
+umount /proc
+umount /sys
+
+print_msg ${VOLUMIO_VERSION}
+print_msg "Finish initramfs, continue booting Volumio"
+exec switch_root /mnt/ext/union /sbin/init
+
+print_msg "Failed to switch_root, dropping to a shell"
+exec sh
+

--- a/scripts/rock64config.sh
+++ b/scripts/rock64config.sh
@@ -3,12 +3,14 @@
 PATCH=$(cat /patch)
 
 # This script will be run in chroot under qemu.
+echo "Initializing.."
+. init.sh
 
 echo "Creating \"fstab\""
 echo "# ROCK64 fstab" > /etc/fstab
 echo "" >> /etc/fstab
 echo "proc            /proc           proc    defaults        0       0
-/dev/mmcblk1p1  /boot           vfat    defaults,utf8,user,rw,umask=111,dmask=000        0       1
+UUID=${UUID_BOOT} /boot           vfat    defaults,utf8,user,rw,umask=111,dmask=000        0       1
 tmpfs   /var/log                tmpfs   size=20M,nodev,uid=1000,mode=0777,gid=4, 0 0
 tmpfs   /var/spool/cups         tmpfs   defaults,noatime,mode=0755 0 0
 tmpfs   /var/spool/cups/tmp     tmpfs   defaults,noatime,mode=0755 0 0
@@ -16,10 +18,18 @@ tmpfs   /tmp                    tmpfs   defaults,noatime,mode=0755 0 0
 tmpfs   /dev/shm                tmpfs   defaults,nosuid,noexec,nodev        0 0
 " > /etc/fstab
 
+echo "Creating boot config"
+echo "label kernel-4.4
+    kernel /Image
+    fdt /rk3328-rock64.dtb
+    initrd /uInitrd
+    append  earlycon=uart8250,mmio32,0xff130000 imgpart=UUID=${UUID_IMG} imgfile=/volumio_current.sqsh hwdevice=Rock64 bootpart=UUID=${UUID_BOOT} datapart=UUID=${UUID_DATA}
+" > /boot/extlinux/extlinux.conf 
+
 echo "#!/bin/sh
 sysctl abi.cp15_barrier=2
 " > /usr/local/bin/rock64-init.sh
-#TODO,. add the following to the init scriüp after verification
+#TODO,. add the following to the init script after verification
 #for i in 1 2 3 ; do
 #	echo 4 >/proc/irq/$(awk -F":" "/xhci/ {print \$1}" </proc/interrupts | sed 's/\ //g')/smp_affinity
 #	echo 8 >/proc/irq/$(awk -F":" "/eth0/ {print \$1}" </proc/interrupts | sed 's/\ //g')/smp_affinity

--- a/scripts/rock64image.sh
+++ b/scripts/rock64image.sh
@@ -112,7 +112,7 @@ mkdir /mnt/volumio/rootfs/boot/dtb
 mkdir /mnt/volumio/rootfs/boot/extlinux
 sudo cp platform-rock64/rock64/boot/Image /mnt/volumio/rootfs/boot
 sudo cp platform-rock64/rock64/boot/dtb/*.dtb /mnt/volumio/rootfs/boot/
-sudo cp platform-rock64/rock64/boot/extlinux/* /mnt/volumio/rootfs/boot/extlinux
+#####################sudo cp platform-rock64/rock64/boot/extlinux/* /mnt/volumio/rootfs/boot/extlinux
 sudo cp platform-rock64/rock64/boot/config* /mnt/volumio/rootfs/boot
 
 echo "Copying rock64 modules and firmware"
@@ -130,7 +130,7 @@ sync
 
 echo "Preparing to run chroot for more rock64 configuration"
 cp scripts/rock64config.sh /mnt/volumio/rootfs
-cp scripts/initramfs/init /mnt/volumio/rootfs/root
+cp scripts/initramfs/init.nextarm /mnt/volumio/rootfs/root/init
 cp scripts/initramfs/mkinitramfs-custom.sh /mnt/volumio/rootfs/usr/local/sbin
 #copy the scripts for updating from usb
 wget -P /mnt/volumio/rootfs/root http://repo.volumio.org/Volumio2/Binaries/volumio-init-updater
@@ -140,13 +140,19 @@ mount /proc /mnt/volumio/rootfs/proc -t proc
 mount /sys /mnt/volumio/rootfs/sys -t sysfs
 echo $PATCH > /mnt/volumio/rootfs/patch
 
+echo "UUID_DATA=$(blkid -s UUID -o value ${DATA_PART})
+UUID_IMG=$(blkid -s UUID -o value ${SYS_PART})
+UUID_BOOT=$(blkid -s UUID -o value ${BOOT_PART})
+" > /mnt/volumio/rootfs/root/init.sh
+chmod +x /mnt/volumio/rootfs/root/init.sh
+
 chroot /mnt/volumio/rootfs /bin/bash -x <<'EOF'
 su -
 /rock64config.sh
 EOF
 
 #cleanup
-rm /mnt/volumio/rootfs/rock64config.sh /mnt/volumio/rootfs/root/init
+rm /mnt/volumio/rootfs/root/init.sh /mnt/volumio/rootfs/rock64config.sh /mnt/volumio/rootfs/root/init
 
 echo "Unmounting Temp devices"
 umount -l /mnt/volumio/rootfs/dev


### PR DESCRIPTION
Changes done on a temporary copy of init (to avoid potential regression).
The Rock64 build implements the new init changes as proposed by @DecayFI (issue #256), but has no working kernel-update capability yet for anything else than /dev/mmc0blk devices (this is still WIP).