### PR TITLE
Run CMD in bash and not in user's standard shell

### DIFF
--- a/volumio/opt/vc/bin/dtoverlay-post
+++ b/volumio/opt/vc/bin/dtoverlay-post
@@ -4,7 +4,7 @@ if [ "$DISPLAY" == "" ]; then
 fi
 CMD="lxpanelctl alsastart >/dev/null"
 if [ $EUID -eq 0 ]; then
-    exec su volumio -c "$CMD"
+    exec su volumio --preserve-environment -c "$CMD"
 else
     exec "$CMD"
 fi

--- a/volumio/opt/vc/bin/dtoverlay-pre
+++ b/volumio/opt/vc/bin/dtoverlay-pre
@@ -4,7 +4,7 @@ if [ "$DISPLAY" == "" ]; then
 fi
 CMD="lxpanelctl alsastop >/dev/null"
 if [ $EUID -eq 0 ]; then
-    exec su volumio -c "$CMD"
+    exec su volumio --preserve-environment -c "$CMD"
 else
     exec "$CMD"
 fi


### PR DESCRIPTION
If the user's shell is set to e.g. fish, running the scripts result in an error like:

    Unsupported use of '&&'. In fish, please use 'COMMAND; and COMMAND'.
    fish: which lxpanelctl >/dev/null 2>&1 && lxpanelctl alsastop >/dev/null

This change ensures that the command is run in bash as well, as specified in the shebang line, and not in the custom user shell.