### PR TITLE
Avoid an error in syslog when there's no wireless hardware

### DIFF
--- a/volumio/bin/hotspot.sh
+++ b/volumio/bin/hotspot.sh
@@ -1,8 +1,19 @@
 #!/bin/bash
 
+INTERFACE=wlan0
+
 case "$1" in
   'start')
-    MODULE=$(basename $(readlink /sys/class/net/wlan0/device/driver/module))
+    modulepath=$(readlink /sys/class/net/${INTERFACE}/device/driver/module)
+    if [ "X" = "X$modulepath" ]; then
+        # Sometimes there is no wireless interface
+        echo "Unable to find driver module name for interface $INTERFACE"
+        echo "Exiting early"
+        exit 1
+    else
+        # Normal case
+        MODULE=$(basename "$modulepath")
+    fi
     ARCH=`/usr/bin/dpkg --print-architecture`
 
     if [ "$MODULE" = "8192cu" ] && [ "$ARCH" = "armhf" ] && !(modinfo "$MODULE" | grep -q '^depends:.*cfg80211.*') ; then


### PR DESCRIPTION
If there is no wireless hardware available, readlink returns an empty string
which causes basename to throw an error.

As far as I can see there's no point running hostapd, so exit.
Exit with an error to prevent dependent systemd units from starting up.