### PR TITLE
Prevent systemd starting hotspot at boot

### DIFF
--- a/scripts/volumioconfig.sh
+++ b/scripts/volumioconfig.sh
@@ -460,6 +460,10 @@ echo "Setting Mpd to SystemD instead of Init"
 update-rc.d mpd remove
 systemctl enable mpd.service
 
+echo "Preventing hotspot services from starting at boot"
+systemctl disable hotspot.service
+systemctl disable dnsmasq.service
+
 echo "Preventing un-needed dhcp servers to start automatically"
 systemctl disable isc-dhcp-server.service
 systemctl disable dhcpd.service

--- a/volumio/lib/systemd/system/hotspot.service
+++ b/volumio/lib/systemd/system/hotspot.service
@@ -1,6 +1,7 @@
 [Unit]
 Wants=dhcpd.service
 Wants=dnsmasq.service
+
 [Service]
 Type=idle
 ExecStart=/bin/hotspot.sh start
@@ -10,5 +11,4 @@ Restart=no
 StandardOutput=syslog
 StandardError=syslog
 SyslogIdentifier=hotspot
-[Install]
-WantedBy=multi-user.target
+


### PR DESCRIPTION
This addresses an issue noticed in #288, that we want hotspot.service to be controlled by wireless.js alone. Allowing systemd to start hotspot.service independently just makes things harder to debug,