### PR TITLE
Fix init.nextarm when not using UUIDs

### DIFF
--- a/scripts/initramfs/init.nextarm
+++ b/scripts/initramfs/init.nextarm
@@ -152,7 +152,7 @@ if [ -z "${IMGFILE}" ]; then
 fi
 
 UUIDFMT=`cat /proc/cmdline | grep "UUID=" -o`
-if [ ! -z "{$UUIDFMT}" ]; then
+if [ ! -z "${UUIDFMT}" ]; then
   if [ $BOOTCONFIG == empty ]; then
     print_msg "Error: when using UUIDs for disk parsing, you MUST also add the bootconfig parameter (eg. bootconfig=/extlinux/extlinux.conf)"
     exec sh


### PR DESCRIPTION
Whilst porting to OrangePi One and Lite devices I discovered a small bug in the `init.nextram` script which checked whether UUIDs were being used was slightly wrong which resulted in the UUID codepath being executed even when UUIDs were not being used.