### PR TITLE
Use a docker container to make images build repeatable and deterministic

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,10 @@ addons:
     packages:
     - shellcheck
 
+before_script:
+ - sudo apt-get --yes --no-install-recommends install binfmt-support qemu-user-static
+ - echo ':arm:M::\x7fELF\x01\x01\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x02\x00\x28\x00:\xff\xff\xff\xff\xff\xff\xff\x00\xff\xff\xff\xff\xff\xff\xff\xff\xfe\xff\xff\xff:/usr/bin/qemu-arm-static:' | sudo tee -a /proc/sys/fs/binfmt_misc/register
+
 services:
  - docker
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,25 @@ services:
 
 env:
  - ARCH=arm BOARD=pi
+ - ARCH=arm BOARD=sparky
+ - ARCH=arm BOARD=bbb
+ - ARCH=arm BOARD=bpim2u
+ - ARCH=armv7 BOARD=cuboxi
+ - ARCH=armv7 BOARD=odroidc1
+ - ARCH=armv7 BOARD=odroidc2
+ - ARCH=armv7 BOARD=odroidxu4
+ - ARCH=armv7 BOARD=odroidx2
+ - ARCH=armv7 BOARD=udooneo
+ - ARCH=armv7 BOARD=udooqdl
+ - ARCH=armv7 BOARD=pine64
+ - ARCH=armv7 BOARD=nanopi64
+ - ARCH=armv7 BOARD=bpipro
+ - ARCH=armv7 BOARD=tinkerboard
+ - ARCH=armv7 BOARD=sopine64
+ - ARCH=armv7 BOARD=rock64
+ - ARCH=armv7 BOARD=voltastream0
+ - ARCH=armv7 BOARD=nanopineo
+ - ARCH=armv7 BOARD=nanopineo2
  - ARCH=x86 BOARD=x86
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: bash
 
-sudo: false
+sudo: required
 
 addons:
   apt:
@@ -9,8 +9,12 @@ addons:
     packages:
     - shellcheck
 
+services:
+ - docker
+
 script:
  - find . -iname "*.sh" -exec shellcheck "{}" \;
+ - ./docker-build.sh -b arm -d pi -v 2.$(git rev-list HEAD --count)
 
 matrix:
   fast_finish: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,9 +12,13 @@ addons:
 services:
  - docker
 
+env:
+ - ARCH=arm BOARD=pi
+ - ARCH=x86 BOARD=x86
+
 script:
  - find . -iname "*.sh" -exec shellcheck "{}" \;
- - ./docker-build.sh -b arm -d pi -v 2.$(git rev-list HEAD --count)
+ - ./docker-build.sh -b ${ARCH} -d ${BOARD} -v 2.$(git rev-list HEAD --count)
 
 matrix:
   fast_finish: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,16 +2,14 @@ language: bash
 
 sudo: required
 
-addons:
-  apt:
-    sources:
-    - debian-sid
-    packages:
-    - shellcheck
-
 before_script:
  - sudo apt-get --yes --no-install-recommends install binfmt-support qemu-user-static
  - echo ':arm:M::\x7fELF\x01\x01\x01\x00\x00\x00\x00\x00\x00\x00\x00\x00\x02\x00\x28\x00:\xff\xff\xff\xff\xff\xff\xff\x00\xff\xff\xff\xff\xff\xff\xff\xff\xfe\xff\xff\xff:/usr/bin/qemu-arm-static:' | sudo tee -a /proc/sys/fs/binfmt_misc/register
+   # Install shellcheck. Workaround for this issue: https://github.com/travis-ci/travis-ci/issues/8823
+ - curl -sSL "https://ftp-master.debian.org/keys/archive-key-7.0.asc" | sudo -E apt-key add -
+ - echo "deb http://ftp.us.debian.org/debian unstable main contrib non-free" | sudo tee -a /etc/apt/sources.list > /dev/null
+ - sudo apt-get update
+ - sudo apt-get install -y shellcheck
 
 services:
  - docker

--- a/docker-build.sh
+++ b/docker-build.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+# Docker based image builder
+#
+# This is an alternative method for building a volumio image that does not
+# require the user to have a debian system with specific packages versions.
+#
+# This method relies on a pre-built docker container that will perform the
+# whole build process and generate the required image in the local directory.
+
+DOCKER="docker"
+
+DPATH=$(which "${DOCKER}" 2> /dev/null)
+FOUND=$?
+RUNDATE=$(date -I)
+
+if [ "${FOUND}" != "0" ]; then
+	echo "You need to have ${DOCKER} installed to be able to perform a Docker based build"
+	exit 1
+fi
+
+if [ $# -lt 2 ]; then
+	echo "Missign build parameters!"
+	echo
+	echo "This script is a wrapper around the main ./build.sh script, and as such it requires specific parameters"
+	echo "to be passed over to build.sh."
+	echo
+	echo "Please run the command ./build.sh without parameters for a full help."
+	exit 2
+fi
+
+${DOCKER} run --name=volumio-build --privileged --tty \
+	-v ${PWD}:/build piffio/volumio-build \
+	$@ | tee docker-build-${RUNDATE}.log

--- a/docker-build.sh
+++ b/docker-build.sh
@@ -29,6 +29,6 @@ if [ $# -lt 2 ]; then
 	exit 2
 fi
 
-${DOCKER} run --name=volumio-build --privileged --tty \
+${DOCKER} run -it --rm --name=volumio-build --privileged \
 	-v ${PWD}:/build piffio/volumio-build \
 	$@ | tee docker-build-${RUNDATE}.log

--- a/docker-build.sh
+++ b/docker-build.sh
@@ -12,7 +12,7 @@ DOCKER="docker"
 
 DPATH=$(which "${DOCKER}" 2> /dev/null)
 FOUND=$?
-RUNDATE=$(date -I)
+RUNDATE=$(date "+%Y-%m-%d")
 
 if [ "${FOUND}" != "0" ]; then
 	echo "You need to have ${DOCKER} installed to be able to perform a Docker based build"

--- a/docker-run.sh
+++ b/docker-run.sh
@@ -1,3 +1,0 @@
-#!/bin/bash
-
-docker run --privileged --tty -v ${PWD}:/build piffio/volumio-build -d pi -b arm -v 3.001

--- a/docker-run.sh
+++ b/docker-run.sh
@@ -1,0 +1,3 @@
+#!/bin/bash
+
+docker run --privileged --tty -v ${PWD}:/build piffio/volumio-build -d pi -b arm -v 3.001


### PR DESCRIPTION
Building images for Volumio requires a Debian system. This might not be available to the end user, or might have some unwanted versions of some packages. All this might render the build of images hard / impossible (like in my Fedora systems), or error prone and hard to reproduce.

This PR is a PoC to show how we could instead rely on a pre-built (and maintained by the Volumio team) docker image to perform the build.

This will have many advantages:

1. Reduce friction / lower the barrier of entry for people who are willing to contribute and / or build their own custom images without having to have spare machines around

2. Allow for easier integration with 3rd party tools for CI / Nightly builds and whatnot

3. Make the builds deterministic since they will always happen on the "same system".

The dockerfile that builds the container is available [in this repo](https://github.com/piffio/volumio-docker-build), and there is a container published on [Docker Hub](https://hub.docker.com/r/piffio/volumio-build/) that this PoC relies on to perform the build.

I am opening the PR mostly a way to start a conversation, since I find it easier to talk around some prototype implementation rather than in pure abstraction.
The PR itself is actually just a one liner invocation of docker, to show how it could be used.
If the idea is approved / considered of interest to the team, I am more than willing to turn the PoC in a proper (set of) PR with all the missing bits and pieces and either integrate with the build.sh script of provide some form of wrapper / alternative build command.