### PR TITLE
Use sudoers.d directory for custom permissions

### DIFF
--- a/scripts/volumioconfig.sh
+++ b/scripts/volumioconfig.sh
@@ -42,7 +42,6 @@ echo ""
 echo "Adding Volumio User"
 groupadd volumio
 useradd -c volumio -d /home/volumio -m -g volumio -G adm,dialout,cdrom,floppy,audio,dip,video,plugdev,netdev -s /bin/bash -p '$6$tRtTtICB$Ki6z.DGyFRopSDJmLUcf3o2P2K8vr5QxRx5yk3lorDrWUhH64GKotIeYSNKefcniSVNcGHlFxZOqLM6xiDa.M.' volumio
-echo "volumio ALL=(ALL) ALL" >> /etc/sudoers
 
 #Setting Root Password
 echo 'root:$1$JVNbxLRo$pNn5AmZxwRtWZ.xF.8xUq/' | chpasswd -e
@@ -93,8 +92,14 @@ alias tvservice="/opt/vc/bin/tvservice"
 ' >> /etc/bash.bashrc
 
 #Sudoers Nopasswd
+SUDOERS_FILE="/etc/sudoers.d/volumio-user"
 echo 'Adding Safe Sudoers NoPassw permissions'
-echo "volumio ALL=(ALL) NOPASSWD: /sbin/poweroff,/sbin/shutdown,/sbin/reboot,/sbin/halt,/bin/systemctl,/usr/bin/apt-get,/usr/sbin/update-rc.d,/usr/bin/gpio,/bin/mount,/bin/umount,/sbin/iwconfig,/sbin/iwlist,/sbin/ifconfig,/usr/bin/killall,/bin/ip,/usr/sbin/service,/etc/init.d/netplug,/bin/journalctl,/bin/chmod,/sbin/ethtool,/usr/sbin/alsactl,/bin/tar,/usr/bin/dtoverlay,/sbin/dhclient,/usr/sbin/i2cdetect,/sbin/dhcpcd,/usr/bin/alsactl,/bin/mv,/sbin/iw,/bin/hostname,/sbin/modprobe,/sbin/iwgetid,/bin/ln,/usr/bin/unlink,/bin/dd,/usr/bin/dcfldd" >> /etc/sudoers
+cat > ${SUDOERS_FILE} << EOF
+# Add permissions for volumio user
+volumio ALL=(ALL) ALL
+volumio ALL=(ALL) NOPASSWD: /sbin/poweroff,/sbin/shutdown,/sbin/reboot,/sbin/halt,/bin/systemctl,/usr/bin/apt-get,/usr/sbin/update-rc.d,/usr/bin/gpio,/bin/mount,/bin/umount,/sbin/iwconfig,/sbin/iwlist,/sbin/ifconfig,/usr/bin/killall,/bin/ip,/usr/sbin/service,/etc/init.d/netplug,/bin/journalctl,/bin/chmod,/sbin/ethtool,/usr/sbin/alsactl,/bin/tar,/usr/bin/dtoverlay,/sbin/dhclient,/usr/sbin/i2cdetect,/sbin/dhcpcd,/usr/bin/alsactl,/bin/mv,/sbin/iw,/bin/hostname,/sbin/modprobe,/sbin/iwgetid,/bin/ln,/usr/bin/unlink,/bin/dd,/usr/bin/dcfldd
+EOF
+chmod 0440 ${SUDOERS_FILE}
 
 echo volumio > /etc/hostname
 chmod 777 /etc/hostname


### PR DESCRIPTION
It is a good practice to leave /etc/sudoers to the official distro
packages, and then create specific files under /etc/sudoers.d for
adding custom configurations.
This ensures that in case of major update of the sudoers file provided
by the official package we don't lose our custom rules while still
benefitting from any major changes happening upstream.

For Volumio, this means creating a /etc/sudoers.d/volumio-user file with
all the relevant configuration.