### PR TITLE
depth 1 for cloning platform files

### DIFF
--- a/scripts/aml805armv7image.sh
+++ b/scripts/aml805armv7image.sh
@@ -69,7 +69,7 @@ then
 	cd ..
 else
 	echo "Clone all AML files from repo"
-	git clone https://github.com/150balbes/platform-aml.git platform-aml
+	git clone --depth 1 https://github.com/150balbes/platform-aml.git platform-aml
 #	cd ..
 fi
 

--- a/scripts/aml812armv7image.sh
+++ b/scripts/aml812armv7image.sh
@@ -69,7 +69,7 @@ then
 	cd ..
 else
 	echo "Clone all AML files from repo"
-	git clone https://github.com/150balbes/platform-aml.git platform-aml
+	git clone --depth 1 https://github.com/150balbes/platform-aml.git platform-aml
 #	cd ..
 fi
 

--- a/scripts/aml9xxxarmv7image.sh
+++ b/scripts/aml9xxxarmv7image.sh
@@ -69,7 +69,7 @@ then
 	cd ..
 else
 	echo "Clone all AML files from repo"
-	git clone https://github.com/150balbes/platform-aml.git platform-aml
+	git clone --depth 1 https://github.com/150balbes/platform-aml.git platform-aml
 #	cd ..
 fi
 

--- a/scripts/bbbimage.sh
+++ b/scripts/bbbimage.sh
@@ -21,7 +21,7 @@ then
 	echo "Platform folder already exists - keeping it"
 else
 	echo "Clone all BBB files from repo"
-	git clone https://github.com/volumio/platform-bbb.git platform-bbb
+	git clone --depth 1 https://github.com/volumio/platform-bbb.git platform-bbb
 fi
 
 BUILDDATE=$(date -I)

--- a/scripts/bpim2uimage.sh
+++ b/scripts/bpim2uimage.sh
@@ -67,7 +67,7 @@ then
     # that will refresh all the bananapi platforms, see below
 else
 	echo "Clone bananapi m2u files from repo"
-	git clone https://github.com/gkkpch/platform-banana.git platform-banana
+	git clone --depth 1 https://github.com/gkkpch/platform-banana.git platform-banana
 	echo "Unpack the platform files"
     cd platform-banana
 	tar xfJ bpi-m2u.tar.xz

--- a/scripts/bpiproimage.sh
+++ b/scripts/bpiproimage.sh
@@ -73,7 +73,7 @@ else
 #	cd platform-banana
 #	tar xfJ bpi-pro.tar.xz
 ### Option 2 - Kernel 3.4.113 chrismade
-	git clone https://github.com/chrismade/platform-banana-pi.git platform-banana
+	git clone --depth 1 https://github.com/chrismade/platform-banana-pi.git platform-banana
 	echo "Unpack the platform files chrismade"
 	cd platform-banana
 	tar xvzf kernel_3_4_113_w_olfs.tgz

--- a/scripts/cuboxiimage.sh
+++ b/scripts/cuboxiimage.sh
@@ -65,7 +65,7 @@ then
     # if you really want to re-clone from the repo, then delete the platforms-cuboxi folder
 else
 	echo "Clone all cubox files from repo"
-	git clone https://github.com/volumio/platform-cuboxi.git platform-cuboxi
+	git clone --depth 1 https://github.com/volumio/platform-cuboxi.git platform-cuboxi
 	echo "Unpack the cubox platform files"
     cd platform-cuboxi
 	tar xfJ cuboxi.tar.xz

--- a/scripts/nanopi64image.sh
+++ b/scripts/nanopi64image.sh
@@ -68,7 +68,7 @@ then
     # that will refresh all the odroid platforms, see below
 else
 	echo "Clone  Nanopi64 files from repo"
-	git clone https://github.com/gkkpch/platform-nanopi platform-nanopi
+	git clone --depth 1 https://github.com/gkkpch/platform-nanopi platform-nanopi
 	echo "Unpack the platform files"
     cd  platform-nanopi
 	tar xfJ nanopi-a64.tar.xz

--- a/scripts/odroidc1image.sh
+++ b/scripts/odroidc1image.sh
@@ -72,7 +72,7 @@ then
 	cd ..
 else
 	echo "Clone all Odroid files from repo"
-	git clone https://github.com/gkkpch/Platform-Odroid.git platform-odroid
+	git clone --depth 1 https://github.com/gkkpch/Platform-Odroid.git platform-odroid
 	echo "Unpack the C1/C1+ platform files"
     cd platform-odroid
 	tar xfJ odroidc1.tar.xz

--- a/scripts/odroidc2image.sh
+++ b/scripts/odroidc2image.sh
@@ -72,7 +72,7 @@ then
 	cd ..
 else
 	echo "Clone all Odroid files from repo"
-	git clone https://github.com/volumio/Platform-Odroid.git platform-odroid
+	git clone --depth 1 https://github.com/volumio/Platform-Odroid.git platform-odroid
 	echo "Unpack the C2 platform files"
     cd platform-odroid
 	tar xfJ odroidc2.tar.xz

--- a/scripts/odroidx2image.sh
+++ b/scripts/odroidx2image.sh
@@ -72,7 +72,7 @@ then
 	cd ..
 else
 	echo "Clone all Odroid files from repo"
-	git clone https://github.com/gkkpch/Platform-Odroid.git platform-odroid
+	git clone --depth 1 https://github.com/gkkpch/Platform-Odroid.git platform-odroid
 	echo "Unpack the X2 platform files"
     cd platform-odroid
     tar xfJ odroidx2.tar.xz

--- a/scripts/odroidxu4image.sh
+++ b/scripts/odroidxu4image.sh
@@ -72,7 +72,7 @@ then
 	cd ..
 else
 	echo "Clone all Odroid files from repo"
-	git clone https://github.com/gkkpch/Platform-Odroid.git platform-odroid
+	git clone --depth 1 https://github.com/gkkpch/Platform-Odroid.git platform-odroid
 	echo "Unpack the XU4 platform files"
     cd platform-odroid
     tar xfJ odroidxu4.tar.xz

--- a/scripts/pine64image.sh
+++ b/scripts/pine64image.sh
@@ -68,7 +68,7 @@ then
     # that will refresh all the odroid platforms, see below
 else
 	echo "Clone (so)Pine64(LTS) files from repo"
-	git clone https://github.com/volumio/platform-pine64.git platform-pine64
+	git clone --depth 1 https://github.com/volumio/platform-pine64.git platform-pine64
 	echo "Unpack the platform files"
     cd platform-pine64
 	tar xfJ sopine64lts.tar.xz

--- a/scripts/rock64image.sh
+++ b/scripts/rock64image.sh
@@ -68,7 +68,7 @@ then
     # that will refresh the platform files, see below
 else
 	echo "Get rock64 files from repo"
-	git clone https://github.com/volumio/platform-rock64.git platform-rock64
+	git clone --depth 1 https://github.com/volumio/platform-rock64.git platform-rock64
 	echo "Unpack the platform files"
     cd platform-rock64
 	tar xfJ rock64.tar.xz

--- a/scripts/sopine64image.sh
+++ b/scripts/sopine64image.sh
@@ -68,7 +68,7 @@ then
     # that will refresh all the odroid platforms, see below
 else
 	echo "Clone (so)Pine64(LTS) files from repo"
-	git clone https://github.com/volumio/platform-pine64.git platform-pine64
+	git clone --depth 1 https://github.com/volumio/platform-pine64.git platform-pine64
 	echo "Unpack the (so)Pine64(LTS) platform files"
     cd platform-pine64
 	tar xfJ sopine64lts.tar.xz

--- a/scripts/sparkyimage.sh
+++ b/scripts/sparkyimage.sh
@@ -66,7 +66,7 @@ then
     # if you really want to re-clone from the repo, then delete the platforms-sparky folder
 else
 	echo "Clone all sparky files from repo"
-	git clone https://github.com/volumio/platform-sparky.git platform-sparky
+	git clone --depth 1 https://github.com/volumio/platform-sparky.git platform-sparky
 	echo "Unpack the sparky platform files"
     cd platform-sparky
 	tar xfJ sparky.tar.xz

--- a/scripts/tinkerimage.sh
+++ b/scripts/tinkerimage.sh
@@ -63,7 +63,7 @@ then
     # that will refresh all the asus platforms, see below
 else
 	echo "Clone asus files from repo"
-	git clone https://github.com/volumio/platform-asus.git platform-asus
+	git clone --depth 1 https://github.com/volumio/platform-asus.git platform-asus
 	echo "Unpack the Tinkerboard platform files"
 	cd platform-asus
 	tar xfJ tinkerboard.tar.xz

--- a/scripts/udooneoimage.sh
+++ b/scripts/udooneoimage.sh
@@ -71,7 +71,7 @@ then
 
 else
 	echo "Clone all UDOO files from repo"
-	git clone https://github.com/volumio/platform-udoo.git platform-udoo
+	git clone --depth 1 https://github.com/volumio/platform-udoo.git platform-udoo
 	echo "Unpack the UDOO  platform files"
     cd platform-udoo
 	tar xfJ udoo-neo.tar.xz

--- a/scripts/udooqdlimage.sh
+++ b/scripts/udooqdlimage.sh
@@ -66,7 +66,7 @@ then
     # if you really want to re-clone from the repo, then delete the platforms-udoo folder
 else
 	echo "Clone all cubox files from repo"
-	git clone https://github.com/volumio/platform-udoo.git platform-udoo
+	git clone --depth 1 https://github.com/volumio/platform-udoo.git platform-udoo
 	echo "Unpack the cubox platform files"
     cd platform-udoo
 	tar xfJ udoo-qdl.tar.xz

--- a/scripts/vszeroimage.sh
+++ b/scripts/vszeroimage.sh
@@ -61,7 +61,7 @@ then
     # that will refresh all the pv platforms, see below
 else
 	echo "Clone Polyvection files from repo"
-	git clone https://github.com/volumio/platform-pv.git platform-pv
+	git clone --depth 1 https://github.com/volumio/platform-pv.git platform-pv
 	echo "Unpack the Voltastream Zero platform files"
 	cd platform-pv
 	tar xfJ vszero.tar.xz

--- a/scripts/x86image.sh
+++ b/scripts/x86image.sh
@@ -82,7 +82,7 @@ sudo mount -t vfat "${BOOT_PART}" /mnt/volumio/rootfs/boot
 cp scripts/x86config.sh /mnt/volumio/rootfs
 if [ ! -d platform-x86 ]; then
   echo "Platform files (packages) not available yet, getting them from the repo"
-  git clone http://github.com/volumio/platform-x86
+  git clone --depth 1 http://github.com/volumio/platform-x86
 fi
 
 if [ -f platform-x86/packages/.next ]; then


### PR DESCRIPTION
Fetching the whole git history for platform files seems unnecessary. Unless there is a reason for current behavior, It's probably better to use --depth 1 when we fetch the platform files.