### PR TITLE
Pass VOLUMIO_ARCH to config.js

### DIFF
--- a/scripts/raspberryimage.sh
+++ b/scripts/raspberryimage.sh
@@ -91,16 +91,20 @@ cp -rp volumio/opt/vc/bin/* /mnt/volumio/rootfs/opt/vc/bin/
 
 echo $PATCH > /mnt/volumio/rootfs/patch
 
+if [ -f "/mnt/volumio/rootfs/etc/os-release" ]; then
+	. "/mnt/volumio/rootfs/etc/os-release"
+fi
+
 if [ -f "/mnt/volumio/rootfs/$PATCH/patch.sh" ] && [ -f "config.js" ]; then
         if [ -f "UIVARIANT" ] && [ -f "variant.js" ]; then
                 UIVARIANT=$(cat "UIVARIANT")
         	echo "Configuring variant $UIVARIANT"
                 echo "Starting config.js for variant $UIVARIANT"
-                node config.js $PATCH $UIVARIANT
+                node config.js $PATCH $VOLUMIO_ARCH $UIVARIANT
                 echo $UIVARIANT > /mnt/volumio/rootfs/UIVARIANT
         else
         	echo "Starting config.js"
-       		node config.js $PATCH
+                node config.js $PATCH $VOLUMIO_ARCH
         fi
 fi
 


### PR DESCRIPTION
We need to run the docker container for the right architecture in
config.js, therefore this script needs to fetch the information from
the release file and pass it over to the node script.

Do not merge until all the required changes are also added to `config.js`