### PR TITLE
Update to stable Node 8 LTS

### DIFF
--- a/scripts/volumioconfig.sh
+++ b/scripts/volumioconfig.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-NODE_VERSION=8.11.1
+NODE_VERSION=8.12.0
 
 # This script will be run in chroot under qemu.
 


### PR DESCRIPTION
Node 8.12.0 includes some minor improvements but most importantly
quite a few security fixes compared to 8.11.1.

Not very easy to test since it requires the specific node version and pre-built node modules to be already available on the update server