### PR TITLE
Solution to issue #347 and #1568

### DIFF
--- a/scripts/raspberryconfig.sh
+++ b/scripts/raspberryconfig.sh
@@ -168,7 +168,9 @@ dtparam=audio=on
 audio_pwm_mode=2
 dtparam=i2c_arm=on
 disable_splash=1
-hdmi_force_hotplug=1" >> /boot/config.txt
+hdmi_force_hotplug=1
+
+#include userconfig.txt" >> /boot/config.txt
 
 echo "Writing cmdline.txt file"
 echo "splash quiet plymouth.ignore-serial-consoles dwc_otg.fiq_enable=1 dwc_otg.fiq_fsm_enable=1 dwc_otg.fiq_fsm_mask=0xF dwc_otg.nak_holdoff=1 console=serial0,115200 kgdboc=serial0,115200 console=tty1 imgpart=/dev/mmcblk0p2 imgfile=/volumio_current.sqsh elevator=noop rootwait bootdelay=5 logo.nologo vt.global_cursor_default=0 loglevel=0" >> /boot/cmdline.txt

--- a/scripts/raspberryconfig.sh
+++ b/scripts/raspberryconfig.sh
@@ -170,7 +170,7 @@ dtparam=i2c_arm=on
 disable_splash=1
 hdmi_force_hotplug=1
 
-#include userconfig.txt" >> /boot/config.txt
+include userconfig.txt" >> /boot/config.txt
 
 echo "Writing cmdline.txt file"
 echo "splash quiet plymouth.ignore-serial-consoles dwc_otg.fiq_enable=1 dwc_otg.fiq_fsm_enable=1 dwc_otg.fiq_fsm_mask=0xF dwc_otg.nak_holdoff=1 console=serial0,115200 kgdboc=serial0,115200 console=tty1 imgpart=/dev/mmcblk0p2 imgfile=/volumio_current.sqsh elevator=noop rootwait bootdelay=5 logo.nologo vt.global_cursor_default=0 loglevel=0" >> /boot/cmdline.txt

--- a/volumio/bin/firststart.sh
+++ b/volumio/bin/firststart.sh
@@ -8,6 +8,9 @@ dpkg --configure --pending
 echo "Creating /var/log/samba folder"
 mkdir /var/log/samba
 
+echo "Creating /boot/userconfig.txt"
+echo "# Add your custom config.txt options to this file, which will be preserved during updates" >> /boot/userconfig.txt
+
 echo "Removing default SSH host keys"
 # These should be created on first boot to ensure they are unique on each system
 rm -v /etc/ssh/ssh_host_*


### PR DESCRIPTION
I suggest to add the include option `#include userconfig.txt` to /boot/config in order to solve issue #347 "System Update does not preserve /boot/config.txt changes (crossref)" respectively [#1568](https://github.com/volumio/Volumio2/issues/1568).

The user would have to fill the predetermined file (/boot/userconfig.txt) with his additions and remove the comment statement (#) from the include option in /boot/config.txt.

On an update the include option would be commented out again (by re-applying the vanilla config.txt) but the additions in userconfig.txt would be preserved. That way the update process would not have to deal with backing up and restoring user made changes and can remain unchanged. Furthermore it would be assured that the system boot will not fail because of user made changes to config.txt. Instead the user has the opportunity to check if the content of the userconfig.txt is still appropriate. If that's the case the include option in /boot/config just has to be uncommented again.