### PR TITLE
Exit build script on failures

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -325,6 +325,11 @@ case "$DEVICE" in
     check_os_release "armv7" "$VERSION" "$DEVICE"
     sh scripts/nanopineoimage.sh -v "$VERSION" -p "$PATCH" -a armv7
     ;;
+  "") echo 'No device specified'
+    ;;
+  *) echo Unknown/Unsupported device: $DEVICE
+    exit 1
+    ;;
 esac
 
 #When the tar is created we can build the docker layer

--- a/build.sh
+++ b/build.sh
@@ -6,6 +6,7 @@
 #
 # Dependencies:
 # parted squashfs-tools dosfstools multistrap qemu binfmt-support qemu-user-static kpartx
+set -eo pipefail
 
 #Set fonts for Help.
 NORM=$(tput sgr0)
@@ -37,7 +38,7 @@ Switches:
 
 Example: Build a Raspberry PI image from scratch, version 2.0 :
          ./build.sh -b arm -d pi -v 2.0 -l reponame
-"
+  "
   exit 1
 }
 
@@ -106,7 +107,7 @@ if [ "$(id -u)" -ne 0 ]; then
 fi
 
 if [ -z "${VARIANT}" ]; then
-   VARIANT="volumio"
+  VARIANT="volumio"
 fi
 
 if [ -n "$BUILD" ]; then
@@ -143,7 +144,12 @@ if [ -n "$BUILD" ]; then
 
   mkdir "build/$BUILD"
   mkdir "build/$BUILD/root"
-  multistrap -a "$ARCH" -f "$CONF"
+
+  if ! multistrap -a "$ARCH" -f "$CONF"
+  then
+    echo multistrap failed. Exitting
+    exit 1
+  fi
   if [ ! "$BUILD" = x86 ]; then
     echo "Build for arm/armv7/armv8 platform, copying qemu"
     cp /usr/bin/qemu-arm-static "build/$BUILD/root/usr/bin/"
@@ -157,10 +163,10 @@ if [ -n "$BUILD" ]; then
   echo 'Cloning Volumio Node Backend'
   mkdir "build/$BUILD/root/volumio"
   if [ -n "$PATCH" ]; then
-      echo "Cloning Volumio with all its history"
-      git clone https://github.com/volumio/Volumio2.git build/$BUILD/root/volumio
+    echo "Cloning Volumio with all its history"
+    git clone https://github.com/volumio/Volumio2.git build/$BUILD/root/volumio
   else
-      git clone --depth 1 -b master --single-branch https://github.com/volumio/Volumio2.git build/$BUILD/root/volumio
+    git clone --depth 1 -b master --single-branch https://github.com/volumio/Volumio2.git build/$BUILD/root/volumio
   fi
   echo 'Cloning Volumio UI'
   git clone --depth 1 -b dist --single-branch https://github.com/volumio/Volumio2-UI.git "build/$BUILD/root/volumio/http/www"
@@ -226,7 +232,7 @@ case "$DEVICE" in
     ;;
   odroidc2) echo 'Writing Odroid-C2 Image File'
     check_os_release "armv7" "$VERSION" "$DEVICE"
-# this will be changed to armv8 once the volumio packges have been re-compiled for aarch64
+    # this will be changed to armv8 once the volumio packges have been re-compiled for aarch64
     sh scripts/odroidc2image.sh -v "$VERSION" -p "$PATCH" -a armv7
     ;;
   odroidxu4) echo 'Writing Odroid-XU4 Image File'
@@ -255,10 +261,10 @@ case "$DEVICE" in
     ;;
   pine64) echo 'Writing Pine64 Image File'
     check_os_release "armv7" "$VERSION" "$DEVICE"
-# this will be changed to armv8 once the volumio packges have been re-compiled for aarch64
+    # this will be changed to armv8 once the volumio packges have been re-compiled for aarch64
     sh scripts/pine64image.sh -v "$VERSION" -p "$PATCH" -a armv7
     ;;
-   nanopi64) echo 'Writing NanoPI A64 Image File'
+    nanopi64) echo 'Writing NanoPI A64 Image File'
     check_os_release "armv7" "$VERSION" "$DEVICE"
     sh scripts/nanopi64image.sh -v "$VERSION" -p "$PATCH" -a armv7
     ;;

--- a/build.sh
+++ b/build.sh
@@ -45,11 +45,11 @@ Example: Build a Raspberry PI image from scratch, version 2.0 :
 #$1 = ${BUILD} $2 = ${VERSION} $3 = ${DEVICE}"
 function check_os_release {
   ARCH_BUILD=$1
-  HAS_VERSION=$(grep -c VOLUMIO_VERSION "build/${ARCH_BUILD}/root/etc/os-release")
   VERSION=$2
   DEVICE=$3
+  HAS_VERSION="grep -c VOLUMIO_VERSION build/${ARCH_BUILD}/root/etc/os-release"
 
-  if [ "$HAS_VERSION" -ne "0" ]; then
+  if $HAS_VERSION; then
     # os-release already has a VERSION number
     # cut the last 2 lines in case other devices are being built from the same rootfs
     head -n -2 "build/${ARCH_BUILD}/root/etc/os-release" > "build/${ARCH_BUILD}/root/etc/tmp-release"
@@ -206,7 +206,7 @@ VOLUMIO_BUILD_DATE=\"${CUR_DATE}\"
   umount -l "build/$BUILD/root/proc"
   umount -l "build/$BUILD/root/sys"
   # Setting up cgmanager under chroot/qemu leaves a mounted fs behind, clean it up
-  umount -l "build/$BUILD/root/run/cgmanager/fs"
+ [ -d "build/$BUILD/root/run/cgmanager/fs" ] && umount -l "build/$BUILD/root/run/cgmanager/fs"
   sh scripts/configure.sh -b "$BUILD"
 fi
 


### PR DESCRIPTION
Especially `multistrap`!
After quite some head scratching as to why my images weren't booting, scrutinised the build process in more detail to discover multistrap was failing. 
This would make errors like #348 easier to catch.



