### PR TITLE
Asus: separate primo from tinkerboard

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -282,6 +282,10 @@ case "$DEVICE" in
     check_os_release "armv7" "$VERSION" "$DEVICE"
     sh scripts/tinkerimage.sh -v "$VERSION" -p "$PATCH" -a armv7
     ;;
+  primo) echo 'Writing Volumio Primo Image File'
+    check_os_release "armv7" "$VERSION" "$DEVICE"
+    sh scripts/primoimage.sh -v "$VERSION" -p "$PATCH" -a armv7
+    ;;
   sopine64) echo 'Writing Sopine64 Image File'
     check_os_release "armv7" "$VERSION" "$DEVICE"
     sh scripts/sopine64image.sh -v "$VERSION" -p "$PATCH" -a armv7

--- a/scripts/primoconfig.sh
+++ b/scripts/primoconfig.sh
@@ -1,0 +1,138 @@
+#!/bin/bash
+
+PATCH=$(cat /patch)
+
+# This script will be run in chroot under qemu.
+echo "Initializing.."
+. init.sh
+
+echo "Creating \"fstab\""
+echo "# Primo fstab" > /etc/fstab
+echo "" >> /etc/fstab
+echo "proc            /proc           proc    defaults        0       0
+UUID=${UUID_BOOT} /boot           vfat    defaults,utf8,user,rw,umask=111,dmask=000        0       1
+tmpfs   /var/log                tmpfs   size=20M,nodev,uid=1000,mode=0777,gid=4, 0 0
+tmpfs   /var/spool/cups         tmpfs   defaults,noatime,mode=0755 0 0
+tmpfs   /var/spool/cups/tmp     tmpfs   defaults,noatime,mode=0755 0 0
+tmpfs   /tmp                    tmpfs   defaults,noatime,mode=0755 0 0
+tmpfs   /dev/shm                tmpfs   defaults,nosuid,noexec,nodev        0 0
+" > /etc/fstab
+
+echo "(Re-)Creating boot config"
+echo "label kernel-4.4
+    kernel /zImage
+    fdt /dtb/rk3288-miniarm.dtb
+    initrd /uInitrd
+    append  earlyprintk splash plymouth.ignore-serial-consoles console=tty1 console=ttyS3,115200n8 rw init=/sbin/init imgpart=UUID=${UUID_IMG} imgfile=/volumio_current.sqsh bootpart=UUID=${UUID_BOOT} datapart=UUID=${UUID_DATA} bootconfig=/extlinux/extlinux.conf
+" > /boot/extlinux/extlinux.conf 
+
+echo "Adding default sound modules"
+#echo "
+#
+#" >> /etc/modules
+
+echo "USB Card Ordering"
+echo "
+options snd-usb-audio nrpacks=1
+# USB DACs will have device number 5 in whole Volumio device range
+options snd-usb-audio index=5" >> /etc/modprobe.d/alsa-base.conf
+
+echo "#!/bin/sh
+echo 2 > /proc/irq/45/smp_affinity
+" > /usr/local/bin/tinker-init.sh
+chmod +x /usr/local/bin/tinker-init.sh
+
+echo "primodac=\`sudo /usr/sbin/i2cdetect -y 1 0x48 0x48 | grep -E 'UU|48' | awk '{print \$2}'\`
+if [ ! -z \"\$primodac\" ]; then
+  configured=\`cat /boot/hw_intf.conf | grep es90x8q2m-dac | awk -F '=' '{print \$2}'\`
+  if [ -z \"\$configured\" ]; then
+    echo \"For information only, you may safely delete this file\" > /boot/dacdetect.log
+    echo \"\`date\`: Volumio Primo DAC detected on i2c address 0x48...\" >> /boot/dacdetect.log
+    volumioconfigured=\`cat /boot/hw_intf.conf | grep \"#### Volumio i2s \" \`
+    if [ ! -z \"\$volumioconfigured\" ]; then
+      echo \"\`date\`: Another DAC configured, wiping it out...\" >> /boot/dacdetect.log
+      mv /boot/hw_intf.conf /boot/hw_intf.tmp
+      sed '/#### Volumio i2s setting below/Q' /boot/hw_intf.tmp >/boot/hw_intf.conf
+      rm /boot/hw_intf.tmp
+    fi
+    echo \"\`date\`: Automatically configuring ES90x8Q2M and reboot...\" >> /boot/dacdetect.log
+    echo \"#### Volumio i2s setting below: do not alter ####\" >> /boot/hw_intf.conf
+    echo \"intf:dtoverlay=es90x8q2m-dac\" >> /boot/hw_intf.conf
+    /sbin/reboot
+  fi
+fi" > /usr/local/bin/detect-primo.sh
+chmod +x /usr/local/bin/detect-primo.sh
+
+echo "#!/bin/sh -e
+/usr/local/bin/tinker-init.sh
+/usr/local/bin/detect-primo.sh
+exit 0" > /etc/rc.local
+
+echo "Installing additonal packages"
+apt-get update
+#apt-get -y install u-boot-tools liblircclient0 lirc
+apt-get -y install u-boot-tools
+
+echo "Configuring boot splash"
+apt-get -y install plymouth plymouth-themes
+plymouth-set-default-theme volumio
+
+echo "Adding custom modules overlay, squashfs and nls_cp437"
+echo "overlay" >> /etc/initramfs-tools/modules
+echo "squashfs" >> /etc/initramfs-tools/modules
+echo "nls_cp437" >> /etc/initramfs-tools/modules
+
+echo "Copying volumio initramfs updater"
+cd /root/
+mv volumio-init-updater /usr/local/sbin
+
+
+echo "Installing Kiosk"
+sh /install-kiosk.sh
+
+echo "Kiosk installed"
+rm /install-kiosk.sh
+#On The Fly Patch
+if [ "$PATCH" = "volumio" ]; then
+echo "No Patch To Apply"
+else
+echo "Applying Patch ${PATCH}"
+PATCHPATH=/${PATCH}
+cd $PATCHPATH
+#Check the existence of patch script
+if [ -f "patch.sh" ]; then
+sh patch.sh
+else
+echo "Cannot Find Patch File, aborting"
+fi
+if [ -f "install.sh" ]; then
+sh install.sh
+fi
+cd /
+rm -rf ${PATCH}
+fi
+rm /patch
+
+echo "Changing to 'modules=dep'"
+sed -i "s/MODULES=most/MODULES=dep/g" /etc/initramfs-tools/initramfs.conf
+
+echo "Installing winbind here, since it freezes networking"
+apt-get update
+apt-get install -y winbind libnss-winbind
+
+echo "Cleaning APT Cache and remove policy file"
+rm -f /var/lib/apt/lists/*archive*
+apt-get clean
+rm /usr/sbin/policy-rc.d
+
+#First Boot operations
+echo "Signalling the init script to re-size the volumio data partition"
+touch /boot/resize-volumio-datapart
+
+echo "Creating initramfs 'volumio.initrd'"
+mkinitramfs-custom.sh -o /tmp/initramfs-tmp
+
+echo "Creating uInitrd from 'volumio.initrd'"
+mkimage -A arm -O linux -T ramdisk -C none -a 0 -e 0 -n uInitrd -d /boot/volumio.initrd /boot/uInitrd
+echo "Cleaning up"
+rm /boot/volumio.initrd

--- a/scripts/primoimage.sh
+++ b/scripts/primoimage.sh
@@ -1,0 +1,213 @@
+#!/bin/sh
+
+# Default build for Debian 32bit
+ARCH="armv7"
+
+while getopts ":d:v:p:" opt; do
+  case $opt in
+    v)
+      VERSION=$OPTARG
+      ;;
+    p)
+      PATCH=$OPTARG
+      ;;
+  esac
+done
+
+BUILDDATE=$(date -I)
+IMG_FILE="Volumio${VERSION}-${BUILDDATE}-primo.img"
+
+if [ "$ARCH" = arm ]; then
+  DISTRO="Raspbian"
+else
+  DISTRO="Debian 32bit"
+fi
+
+echo "Creating Image File ${IMG_FILE} with $DISTRO rootfs"
+dd if=/dev/zero of=${IMG_FILE} bs=1M count=2800
+
+echo "Creating Image Bed"
+LOOP_DEV=`sudo losetup -f --show ${IMG_FILE}`
+parted -s "${LOOP_DEV}" mklabel msdos
+parted -s "${LOOP_DEV}" mkpart primary fat32 1 64
+parted -s "${LOOP_DEV}" mkpart primary ext3 65 2500
+parted -s "${LOOP_DEV}" mkpart primary ext3 2500 100%
+parted -s "${LOOP_DEV}" set 1 boot on
+parted -s "${LOOP_DEV}" print
+partprobe "${LOOP_DEV}"
+kpartx -s -a "${LOOP_DEV}"
+
+BOOT_PART=`echo /dev/mapper/"$( echo ${LOOP_DEV} | sed -e 's/.*\/\(\w*\)/\1/' )"p1`
+SYS_PART=`echo /dev/mapper/"$( echo ${LOOP_DEV} | sed -e 's/.*\/\(\w*\)/\1/' )"p2`
+DATA_PART=`echo /dev/mapper/"$( echo ${LOOP_DEV} | sed -e 's/.*\/\(\w*\)/\1/' )"p3`
+echo "Using: " ${BOOT_PART}
+echo "Using: " ${SYS_PART}
+echo "Using: " ${DATA_PART}
+if [ ! -b "${BOOT_PART}" ]
+then
+	echo "${BOOT_PART} doesn't exist"
+	exit 1
+fi
+
+echo "Creating boot and rootfs filesystems"
+mkfs -t vfat -n BOOT "${BOOT_PART}"
+mkfs -F -t ext4 -L volumio "${SYS_PART}"
+mkfs -F -t ext4 -L volumio_data "${DATA_PART}"
+sync
+
+echo "Preparing for the Primo (tinkerboard) rockchip kernel/ platform files"
+if [ -d platform-primo ]
+then
+	echo "Platform folder already exists - keeping it"
+    # if you really want to re-clone from the repo, then delete the platform-primo folder
+    # that will refresh all the primo platforms, see below
+else
+	echo "Clone primo files from repo"
+	git clone --depth 1 https://github.com/volumio/platform-primo.git platform-primo
+	echo "Unpack the Volumio Primo platform files"
+	cd platform-primo
+	tar xfJ primo.tar.xz
+	cd ..
+fi
+
+echo "Copying the bootloader"
+dd if=platform-primo/primo/u-boot/u-boot.img of=${LOOP_DEV} seek=64 conv=notrunc
+sync
+
+if [ -d /mnt ]
+then
+	echo "/mount folder exist"
+else
+	mkdir /mnt
+fi
+if [ -d /mnt/volumio ]
+then
+	echo "Volumio Temp Directory Exists - Cleaning it"
+	rm -rf /mnt/volumio/*
+else
+	echo "Creating Volumio Temp Directory"
+	sudo mkdir /mnt/volumio
+fi
+
+echo "Creating mount point for the images partition"
+mkdir /mnt/volumio/images
+mount -t ext4 "${SYS_PART}" /mnt/volumio/images
+mkdir /mnt/volumio/rootfs
+echo "Creating mount point for the boot partition"
+mkdir /mnt/volumio/rootfs/boot
+mount -t vfat "${BOOT_PART}" /mnt/volumio/rootfs/boot
+
+echo "Copying Volumio RootFs"
+cp -pdR build/$ARCH/root/* /mnt/volumio/rootfs
+echo "Copying Primo boot files"
+cp -R platform-primo/primo/boot/* /mnt/volumio/rootfs/boot/
+
+echo "Copying Primo modules and firmware"
+cp -pdR platform-primo/primo/lib/modules /mnt/volumio/rootfs/lib/
+cp -pdR platform-primo/primo/lib/firmware /mnt/volumio/rootfs/lib/
+sync
+
+echo "Preparing to run chroot for more Primo configuration"
+cp scripts/primoconfig.sh /mnt/volumio/rootfs
+cp scripts/install-kiosk.sh /mnt/volumio/rootfs
+cp scripts/initramfs/init.nextarm /mnt/volumio/rootfs/root/init
+cp scripts/initramfs/mkinitramfs-custom.sh /mnt/volumio/rootfs/usr/local/sbin
+#copy the scripts for updating from usb
+wget -P /mnt/volumio/rootfs/root http://repo.volumio.org/Volumio2/Binaries/volumio-init-updater
+
+mount /dev /mnt/volumio/rootfs/dev -o bind
+mount /proc /mnt/volumio/rootfs/proc -t proc
+mount /sys /mnt/volumio/rootfs/sys -t sysfs
+echo $PATCH > /mnt/volumio/rootfs/patch
+
+if [ -f "/mnt/volumio/rootfs/$PATCH/patch.sh" ] && [ -f "config.js" ]; then
+        if [ -f "UIVARIANT" ] && [ -f "variant.js" ]; then
+                UIVARIANT=$(cat "UIVARIANT")
+        	echo "Configuring variant $UIVARIANT"
+                echo "Starting config.js for variant $UIVARIANT"
+                node config.js $PATCH $UIVARIANT
+                echo $UIVARIANT > /mnt/volumio/rootfs/UIVARIANT
+        else
+        	echo "Starting config.js"
+       		node config.js $PATCH
+        fi
+fi
+
+echo "UUID_DATA=$(blkid -s UUID -o value ${DATA_PART})
+UUID_IMG=$(blkid -s UUID -o value ${SYS_PART})
+UUID_BOOT=$(blkid -s UUID -o value ${BOOT_PART})
+" > /mnt/volumio/rootfs/root/init.sh
+chmod +x /mnt/volumio/rootfs/root/init.sh
+
+chroot /mnt/volumio/rootfs /bin/bash -x <<'EOF'
+su -
+/primoconfig.sh
+EOF
+
+#cleanup
+rm /mnt/volumio/rootfs/root/init.sh /mnt/volumio/rootfs/root/init /mnt/volumio/rootfs/primoconfig.sh
+
+UIVARIANT_FILE=/mnt/volumio/rootfs/UIVARIANT
+if [ -f "${UIVARIANT_FILE}" ]; then
+    echo "Starting variant.js"
+    node variant.js
+    rm $UIVARIANT_FILE
+fi
+
+echo "Unmounting Temp devices"
+umount -l /mnt/volumio/rootfs/dev
+umount -l /mnt/volumio/rootfs/proc
+umount -l /mnt/volumio/rootfs/sys
+
+echo "==> Volumio Primo device installed"
+
+#echo "Removing temporary platform files"
+#echo "(you can keep it safely as long as you're sure of no changes)"
+#rm -r platform-asus
+sync
+
+echo "Finalizing Rootfs creation"
+sh scripts/finalize.sh
+
+echo "Preparing rootfs base for SquashFS"
+
+if [ -d /mnt/squash ]; then
+	echo "Volumio SquashFS Temp Dir Exists - Cleaning it"
+	rm -rf /mnt/squash/*
+else
+	echo "Creating Volumio SquashFS Temp Dir"
+	mkdir /mnt/squash
+fi
+
+echo "Copying Volumio rootfs to Temp Dir"
+cp -rp /mnt/volumio/rootfs/* /mnt/squash/
+
+if [ -e /mnt/kernel_current.tar ]; then
+	echo "Volumio Kernel Partition Archive exists - Cleaning it"
+	rm -rf /mnt/kernel_current.tar
+fi
+
+echo "Creating Kernel Partition Archive"
+tar cf /mnt/kernel_current.tar --exclude='resize-volumio-datapart' -C /mnt/squash/boot/ .
+
+echo "Removing the Kernel"
+rm -rf /mnt/squash/boot/*
+
+echo "Creating SquashFS, removing any previous one"
+rm -r Volumio.sqsh
+mksquashfs /mnt/squash/* Volumio.sqsh
+
+echo "Squash filesystem created"
+echo "Cleaning squash environment"
+rm -rf /mnt/squash
+
+#copy the squash image inside the boot partition
+cp Volumio.sqsh /mnt/volumio/images/volumio_current.sqsh
+sync
+echo "Unmounting Temp Devices"
+umount -l /mnt/volumio/images
+umount -l /mnt/volumio/rootfs/boot
+
+dmsetup remove_all
+losetup -d ${LOOP_DEV}
+sync


### PR DESCRIPTION
Currently the only difference is the kernel with a fix for the DAC frequency problems. Primo uses our corrected DAC driver with kernel version 4.4.132, while the tinkerboard remains on kernel 4.4.71+ until Asus corrects the DAC drivers they support.