### PR TITLE
Configure a Samba password for volumio user

### DIFF
--- a/scripts/configure.sh
+++ b/scripts/configure.sh
@@ -40,6 +40,8 @@ cp volumio/etc/dhcp/dhclient.conf build/$BUILD/root/etc/dhcp/dhclient.conf
 cp volumio/etc/dhcp/dhcpd.conf build/$BUILD/root/etc/dhcp/dhcpd.conf
 #Samba conf file
 cp volumio/etc/samba/smb.conf build/$BUILD/root/etc/samba/smb.conf
+#Set a samba password for the volumio user
+smbpasswd -a volumio <<< $'volumio\nvolumio\n'
 #Udev confs file (NET)
 cp -r volumio/etc/udev build/$BUILD/root/etc/
 #Udisks-glue for USB

--- a/scripts/volumioconfig.sh
+++ b/scripts/volumioconfig.sh
@@ -63,6 +63,8 @@ echo ""
 echo "Adding Volumio User"
 groupadd volumio
 useradd -c volumio -d /home/volumio -m -g volumio -G adm,dialout,cdrom,floppy,audio,dip,video,plugdev,netdev,lp -s /bin/bash -p '$6$tRtTtICB$Ki6z.DGyFRopSDJmLUcf3o2P2K8vr5QxRx5yk3lorDrWUhH64GKotIeYSNKefcniSVNcGHlFxZOqLM6xiDa.M.' volumio
+#Note that for samba access, system users are used, but with different passwords
+#This is setup for the volumio user in configure.sh
 
 #Setting Root Password
 echo 'root:$1$JVNbxLRo$pNn5AmZxwRtWZ.xF.8xUq/' | chpasswd -e


### PR DESCRIPTION
Samba uses system users for access control, but uses independent
passwords. This configures a default password for the volumio user upon
system configuration.

This PR is split out from functionality I originally put in volumio/Volumio2#1883, for rationale and discussion, see there. The two PRs are not dependent on each other though, and can thus be merged independently.

**Note:** This adds the volumio default password ("volumio") as cleartext to the codebase. That's not ideal, but given the security of the default password not such a big problem. If that is undesirable, I could investigate whether it is possible to provide the password hash or even the complete samba password DB as a file (instead of using `smbpasswd`).