### PR TITLE
Pi: update brcm firmware & improve BT coexistence

### DIFF
--- a/scripts/raspberryconfig.sh
+++ b/scripts/raspberryconfig.sh
@@ -168,9 +168,9 @@ echo "Adding PI3 & PiZero W Wireless, PI WIFI Wireless dongle, ralink mt7601u & 
 apt-get install -y --only-upgrade firmware-atheros firmware-ralink firmware-realtek firmware-brcm80211
 
 # Temporary brcm firmware fix solution until we use Buster 
-wget http://repo.volumio.org/Volumio2/Firmwares/firmware-brcm80211_20190114-1+rpt2_all.deb
-dpkg -i firmware-brcm80211_20190114-1+rpt2_all.deb
-rm firmware-brcm80211_20190114-1+rpt2_all.deb
+wget http://repo.volumio.org/Volumio2/Firmwares/firmware-brcm80211_20190114-1+rpt6_all.deb
+dpkg -i firmware-brcm80211_20190114-1+rpt6_all.deb
+rm firmware-brcm80211_20190114-1+rpt6_all.deb
 
 if [ "$KERNEL_VERSION" = "4.4.9" ]; then       # probably won't be necessary in future kernels 
 echo "Adding initial support for PiZero W wireless on 4.4.9 kernel"


### PR DESCRIPTION
https://github.com/RPi-Distro/firmware-nonfree/issues/8#issuecomment-615339218
(need to get file from https://archive.raspberrypi.org/debian/pool/main/f/firmware-nonfree/firmware-brcm80211_20190114-1+rpt6_all.deb )