### PR TITLE
moved 'rm -rf .git' after 'git rev-parse HEAD'

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -186,8 +186,6 @@ if [ -n "$BUILD" ]; then
   git clone --depth 1 -b dist --single-branch https://github.com/volumio/Volumio2-UI.git "build/$BUILD/root/volumio/http/www"
   echo 'Cloning Volumio3 UI'
   git clone --depth 1 -b dist3 --single-branch https://github.com/volumio/Volumio2-UI.git "build/$BUILD/root/volumio/http/www3"
-  rm -rf build/$BUILD/root/volumio/http/www/.git
-  rm -rf build/$BUILD/root/volumio/http/www3/.git
   echo "Adding os-release infos"
   {
     echo "VOLUMIO_BUILD_VERSION=\"$(git rev-parse HEAD)\""
@@ -195,6 +193,9 @@ if [ -n "$BUILD" ]; then
     echo "VOLUMIO_BE_VERSION=\"$(git --git-dir "build/$BUILD/root/volumio/.git" rev-parse HEAD)\""
     echo "VOLUMIO_ARCH=\"${BUILD}\""
   } >> "build/$BUILD/root/etc/os-release"
+  rm -rf build/$BUILD/root/volumio/.git
+  rm -rf build/$BUILD/root/volumio/http/www/.git
+  rm -rf build/$BUILD/root/volumio/http/www3/.git
   
   if [ ! "$BUILD" = x86 ]; then
     chroot "build/$BUILD/root" /bin/bash -x <<'EOF'

--- a/build.sh
+++ b/build.sh
@@ -193,7 +193,6 @@ if [ -n "$BUILD" ]; then
     echo "VOLUMIO_BE_VERSION=\"$(git --git-dir "build/$BUILD/root/volumio/.git" rev-parse HEAD)\""
     echo "VOLUMIO_ARCH=\"${BUILD}\""
   } >> "build/$BUILD/root/etc/os-release"
-  rm -rf build/$BUILD/root/volumio/.git
   rm -rf build/$BUILD/root/volumio/http/www/.git
   rm -rf build/$BUILD/root/volumio/http/www3/.git
   


### PR DESCRIPTION
`VOLUMIO_FE_VERSION` in `/etc/os-release` was empty.

Reason:

Folder `/volumio/http/www/.git` was deleted before `git ... rev-parse HEAD`

So I moved the deletion after writing version information to `/etc/os-release`.