### PR TITLE
Repair 92-gpio.rules

### DIFF
--- a/volumio/etc/udev/rules.d/92-gpio.rules
+++ b/volumio/etc/udev/rules.d/92-gpio.rules
@@ -1,2 +1,2 @@
-SUBSYSTEM=="gpio", KERNEL=="gpiochip*", ACTION=="add", PROGRAM="/bin/sh -c 'chown volumio:volumio /sys/class/gpio/export /sys/class/gpio/unexport ; chmod 220 /sys/class/gpio/export /sys/class/gpio/unexport'" SUBSYSTEM=="gpio", 
-KERNEL=="gpio*", ACTION=="add", PROGRAM="/bin/sh -c 'chown volumio:volumio /sys%p/active_low /sys%p/direction /sys%p/edge /sys%p/value ; chmod 660 /sys%p/active_low /sys%p/direction /sys%p/edge /sys%p/value'"
+SUBSYSTEM=="gpio", KERNEL=="gpiochip*", ACTION=="add", PROGRAM="/bin/sh -c 'chown volumio:volumio /sys/class/gpio/export /sys/class/gpio/unexport ; chmod 220 /sys/class/gpio/export /sys/class/gpio/unexport'"
+SUBSYSTEM=="gpio", KERNEL=="gpio*", ACTION=="add", PROGRAM="/bin/sh -c 'chown volumio:volumio /sys%p/active_low /sys%p/direction /sys%p/edge /sys%p/value ; chmod 660 /sys%p/active_low /sys%p/direction /sys%p/edge /sys%p/value'"


### PR DESCRIPTION
Corrected wrong line feeds causing 92-gpio.rules to fail with error message `invalid key/value pair in file /etc/udev/rules.d/92-gpio.rules on line 1,starting at character 226 (' ')`.