### PR TITLE
fix dynswap.sh

### DIFF
--- a/volumio/bin/dynswap.sh
+++ b/volumio/bin/dynswap.sh
@@ -5,18 +5,20 @@ SWAPDEVS=`cat /proc/swaps | wc -l`
 
 if [ ${RAMSIZE} -le 512844 -a ${SWAPDEVS} -le 1 ]; then
     echo "512 MB or less RAM Detected, need to enable swap"
-    if [ ! -e /data/swapfile ]; then
+    [ -d /swap ] || mkdir -m 700 /swap
+    mount -L volumio_data /swap
+    if [ ! -e /swap/swapfile ]; then
 	echo "No Swapfile present, creating it..."
-	fallocate -l 512M /data/swapfile
+	fallocate -l 512M /swap/swapfile
 	echo "Securing Swap permissions"
-	chown root:root /data/swapfile
-	chmod 0600 /data/swapfile
+	chown root:root /swap/swapfile
+	chmod 0600 /swap/swapfile
 	echo "Preparing SwapFile"
-	mkswap /data/swapfile
+	mkswap /swap/swapfile
     fi
 	
     echo "Enabling Swap"
-    swapon /data/swapfile
+    swapon /swap/swapfile
     echo "Setting swappiness to 40"
     sysctl vm.swappiness=40
 fi


### PR DESCRIPTION
as per issue https://github.com/volumio/Build/issues/399
`/data` is part of overlay, and can not be used for swap.
`swapon: /data/swapfile: swapon failed: Invalid argument`

Mount partition into new `/swap`, and enable swapfile as before