### PR TITLE
Tweak boards to use `BOOT_USE_UUID`, fix some syntax errors..

### DIFF
--- a/recipes/devices/families/kvims.sh
+++ b/recipes/devices/families/kvims.sh
@@ -11,7 +11,7 @@ BUILD="armv7"
 
 ### Device information
 # This is useful for multiple devices sharing the same/similar kernel
-DEVICENAME="not set here"
+#DEVICENAME="not set here"
 DEVICEFAMILY="khadas"
 #DEVICEBASE=${DEVICE} # Defaults to ${DEVICE} if unset
 DEVICEBASE="vims"
@@ -28,13 +28,14 @@ KIOSKMODE=no
 BOOT_START=16
 BOOT_END=80
 BOOT_TYPE=msdos          # msdos or gpt
+BOOT_USE_UUID=yes        # Add UUID to fstab
 INIT_TYPE="init.nextarm" # init.{x86/nextarm/nextarm_tvbox}
 
 # Modules that will be added to intramsfs
 MODULES=("overlay" "squashfs" "nls_cp437")
 # Packages that will be installed
-PACKAGES=("u-boot-tools" "lirc" "fbset" "mc" "abootimg" "bluez-firmware" 
-"bluetooth" "bluez" "bluez-tools" "linux-base" "triggerhappy"
+PACKAGES=("u-boot-tools" "lirc" "fbset" "mc" "abootimg" "bluez-firmware"
+  "bluetooth" "bluez" "bluez-tools" "linux-base" "triggerhappy"
 )
 
 ### Device customisation
@@ -45,8 +46,8 @@ write_device_files() {
   cp -R "${PLTDIR}/${DEVICEBASE}/boot" "${ROOTFSMNT}"
 
   log "AML autoscripts not for Volumio"
-  rm  "${ROOTFSMNT}/boot/aml_autoscript" 
-  rm  "${ROOTFSMNT}/boot/aml_autoscript.cmd" 
+  rm "${ROOTFSMNT}/boot/aml_autoscript"
+  rm "${ROOTFSMNT}/boot/aml_autoscript.cmd"
 
   log "Retain copies of u-boot files for Volumio Updater"
   cp -r "${PLTDIR}/${DEVICEBASE}/uboot" "${ROOTFSMNT}/boot"
@@ -54,9 +55,9 @@ write_device_files() {
 
   log "Copying modules & firmware"
   cp -pR "${PLTDIR}/${DEVICEBASE}/lib/modules" "${ROOTFSMNT}/lib"
-  cp -pR "${PLTDIR}/${DEVICEBASE}/lib/firmware" "${ROOTFSMNT}/lib"  
+  cp -pR "${PLTDIR}/${DEVICEBASE}/lib/firmware" "${ROOTFSMNT}/lib"
 
-  log "Adding broadcom wlan firmware for vims onboard wlan" 
+  log "Adding broadcom wlan firmware for vims onboard wlan"
   cp -pR "${PLTDIR}/${DEVICEBASE}/hwpacks/wlan-firmware/brcm/" "${ROOTFSMNT}/lib/firmware"
 
   log "Adding Meson video firmware"
@@ -67,22 +68,22 @@ write_device_files() {
   cp "${PLTDIR}/${DEVICEBASE}/hwpacks/bluez/hciattach-armhf" "${ROOTFSMNT}/usr/local/bin/hciattach"
   cp "${PLTDIR}/${DEVICEBASE}/hwpacks/bluez/brcm_patchram_plus-armhf" "${ROOTFSMNT}/usr/local/bin/brcm_patchram_plus"
   if [ "${DEVICE}" = kvim3 ] || [ "${DEVICE}" = mp1 ]; then
-	log "   For VIM3/MP1: fix issue with AP6359SA and AP6398S using the same chipid and rev"
-	mv "${ROOTFSMNT}/lib/firmware/brcm/fw_bcm4359c0_ag_apsta_ap6398s.bin" "${ROOTFSMNT}/lib/firmware/brcm/fw_bcm4359c0_ag_apsta.bin"
-	mv "${ROOTFSMNT}/lib/firmware/brcm/fw_bcm4359c0_ag_ap6398s.bin" "${ROOTFSMNT}/lib/firmware/brcm/fw_bcm4359c0_ag.bin"
-	mv "${ROOTFSMNT}/lib/firmware/brcm/nvram_ap6398s.txt" "${ROOTFSMNT}/lib/firmware/brcm/nvram_ap6359sa.txt"
-	mv "${ROOTFSMNT}/lib/firmware/brcm/BCM4359C0_ap6398s.hcd" "${ROOTFSMNT}/lib/firmware/brcm/BCM4359C0.hcd"
-#	cp "${PLTDIR}/${DEVICEBASE}/var/lib/alsa/asound.state.vim3-3l" "${ROOTFSMNT}/var/lib/alsa/asound.state"
-# else
-#	cp "${PLTDIR}/${DEVICEBASE}/var/lib/alsa/asound.state.vim1-2" "${ROOTFSMNT}/var/lib/alsa/asound.state"
-fi
- 
+    log "   For VIM3/MP1: fix issue with AP6359SA and AP6398S using the same chipid and rev"
+    mv "${ROOTFSMNT}/lib/firmware/brcm/fw_bcm4359c0_ag_apsta_ap6398s.bin" "${ROOTFSMNT}/lib/firmware/brcm/fw_bcm4359c0_ag_apsta.bin"
+    mv "${ROOTFSMNT}/lib/firmware/brcm/fw_bcm4359c0_ag_ap6398s.bin" "${ROOTFSMNT}/lib/firmware/brcm/fw_bcm4359c0_ag.bin"
+    mv "${ROOTFSMNT}/lib/firmware/brcm/nvram_ap6398s.txt" "${ROOTFSMNT}/lib/firmware/brcm/nvram_ap6359sa.txt"
+    mv "${ROOTFSMNT}/lib/firmware/brcm/BCM4359C0_ap6398s.hcd" "${ROOTFSMNT}/lib/firmware/brcm/BCM4359C0.hcd"
+  #	cp "${PLTDIR}/${DEVICEBASE}/var/lib/alsa/asound.state.vim3-3l" "${ROOTFSMNT}/var/lib/alsa/asound.state"
+  # else
+  #	cp "${PLTDIR}/${DEVICEBASE}/var/lib/alsa/asound.state.vim1-2" "${ROOTFSMNT}/var/lib/alsa/asound.state"
+  fi
+
   log "Adding services"
   mkdir -p "${ROOTFSMNT}/lib/systemd/system"
   cp "${PLTDIR}/${DEVICEBASE}/lib/systemd/system/bluetooth-khadas.service" "${ROOTFSMNT}/lib/systemd/system"
-  if [ ! "$DEVICE}" = kvim1 ];then
-	cp "${PLTDIR}/${DEVICEBASE}/lib/systemd/system/fan.service" "${ROOTFSMNT}/lib/systemd/system"
-  fi	
+  if [[ "${DEVICE}" != kvim1 ]]; then
+    cp "${PLTDIR}/${DEVICEBASE}/lib/systemd/system/fan.service" "${ROOTFSMNT}/lib/systemd/system"
+  fi
 
   log "Adding usr/local/bin & usr/bin files"
   cp -pR "${PLTDIR}/${DEVICEBASE}/usr" "${ROOTFSMNT}"
@@ -93,23 +94,23 @@ fi
   log "Copying triggerhappy configuration"
   cp -pR "${PLTDIR}/${DEVICEBASE}/etc/triggerhappy" "${ROOTFSMNT}/etc"
 
-#TODO: remove the mp1 restriction when reboot works
-if [ ! "${DEVICE}" = mp1 ]; then
-	echo "Copying khadas system halt service"
-	cp -pR "${PLTDIR}/${DEVICEBASE}/etc/systemd "${ROOTFSMNT}/etc"
-	cp "${PLTDIR}/${DEVICEBASE}/opt/poweroff "${ROOTFSMNT}/opt/poweroff"
-else
-#do not use the system-halt.service for mp1 yet
+  #TODO: remove the mp1 restriction when reboot works
+  if [[ "${DEVICE}" != mp1 ]]; then
+    echo "Copying khadas system halt service"
+    cp -pR "${PLTDIR}/${DEVICEBASE}"/etc/systemd "${ROOTFSMNT}/etc"
+    cp "${PLTDIR}/${DEVICEBASE}"/opt/poweroff "${ROOTFSMNT}/opt/poweroff"
+  else
+    #do not use the system-halt.service for mp1 yet
     cp "${PLTDIR}/${DEVICEBASE}/etc/rc.local.mp1" "${ROOTFSMNT}/etc/rc.local"
-fi
+  fi
 
 }
 
 write_device_bootloader() {
   log "Running write_device_bootloader u-boot.$BOARD.sd.bin" "ext"
- 
-  dd if="${PLTDIR}/${DEVICEBASE}/uboot/u-boot.${KHADASBOARDNAME}.sd.bin" of=${LOOP_DEV} bs=444 count=1 conv=fsync> /dev/null 2>&1
-  dd if="${PLTDIR}/${DEVICEBASE}/uboot/u-boot.${KHADASBOARDNAME}.sd.bin" of=${LOOP_DEV} bs=512 skip=1 seek=1 conv=fsync > /dev/null 2>&1
+
+  dd if="${PLTDIR}/${DEVICEBASE}/uboot/u-boot.${KHADASBOARDNAME}.sd.bin" of="${LOOP_DEV}" bs=444 count=1 conv=fsync >/dev/null 2>&1
+  dd if="${PLTDIR}/${DEVICEBASE}/uboot/u-boot.${KHADASBOARDNAME}.sd.bin" of="${LOOP_DEV}" bs=512 skip=1 seek=1 conv=fsync >/dev/null 2>&1
 
 }
 
@@ -121,8 +122,6 @@ device_image_tweaks() {
 # Will be run in chroot - Pre initramfs
 device_chroot_tweaks_pre() {
   log "Performing device_chroot_tweaks_pre" "ext"
-  log "Update fstab with UUIDs"
-  sed -i "s_/dev/mmcblk0p1_UUID=${UUID_BOOT}_" /etc/fstab
 
   log "Creating boot parameters from template"
   sed -i "s/#imgpart=UUID=/imgpart=UUID=${UUID_IMG}/g" /boot/env.system.txt
@@ -130,13 +129,13 @@ device_chroot_tweaks_pre() {
   sed -i "s/#datapart=UUID=/datapart=UUID=${UUID_DATA}/g" /boot/env.system.txt
 
   log "Fixing armv8 deprecated instruction emulation, allow dmesg"
-  cat <<-EOF >> /etc/sysctl.conf
-abi.cp15_barrier=2
-kernel.dmesg_restrict=0
-EOF
+  cat <<-EOF >>/etc/sysctl.conf
+	abi.cp15_barrier=2
+	kernel.dmesg_restrict=0
+	EOF
 
   log "Adding default wifi"
-  echo "dhd" >> "/etc/modules"
+  echo "dhd" >>"/etc/modules"
 }
 
 # Will be run in chroot - Post initramfs
@@ -144,14 +143,14 @@ device_chroot_tweaks_post() {
   log "Running device_chroot_tweaks_post" "ext"
 
   log "Configure triggerhappy"
-  echo "DAEMON_OPTS=\"--user root\"" >> "/etc/default/triggerhappy"
+  echo "DAEMON_OPTS=\"--user root\"" >>"/etc/default/triggerhappy"
 
   log "Enabling KVIM Bluetooth stack"
   ln -sf "/lib/firmware" "/etc/firmware"
   ln -s "/lib/systemd/system/bluetooth-khadas.service" "/etc/systemd/system/multi-user.target.wants/bluetooth-khadas.service"
 
-  if [ ! "{$DEVICE}" = kvim1 ]; then
-	ln -s "/lib/systemd/system/fan.service" "/etc/systemd/system/multi-user.target.wants/fan.service"
+  if [[ "${DEVICE}" != kvim1 ]]; then
+    ln -s "/lib/systemd/system/fan.service" "/etc/systemd/system/multi-user.target.wants/fan.service"
   fi
 
   #TODO This can be done outside chroot,

--- a/recipes/devices/families/x86.sh
+++ b/recipes/devices/families/x86.sh
@@ -28,8 +28,8 @@ KIOSKMODE=yes
 ## Partition info
 BOOT_START=1
 BOOT_END=512
-BOOT_TYPE=gpt # msdos or gpt
-BOOT_USE_UUID=yes
+BOOT_TYPE=gpt        # msdos or gpt
+BOOT_USE_UUID=yes    # Add UUID to fstab
 INIT_TYPE="init.x86" # init.{x86/nextarm/nextarm_tvbox}
 
 # Modules that will be added to intramfs

--- a/recipes/devices/motivo.sh
+++ b/recipes/devices/motivo.sh
@@ -28,17 +28,18 @@ BOOT_START=21
 BOOT_END=84
 IMAGE_END=3200
 BOOT_TYPE=msdos          # msdos or gpt
+BOOT_USE_UUID=yes        # Add UUID to fstab
 INIT_TYPE="init.nextarm" # init.{x86/nextarm/nextarm_tvbox}
 
 # Modules that will be added to intramsfs
 MODULES=(
   # Base for initramfs
-  "overlay" "squashfs" "nls_cp437" 
+  "overlay" "squashfs" "nls_cp437"
   # Touchscreen panels
   "panel-feiyang-fy07024di26a30d" "panel-motivo-mt1280800"
   # lima
   "lima"
- ) 
+)
 
 # Packages that will be installed
 PACKAGES=(
@@ -79,38 +80,36 @@ write_device_files() {
 write_device_bootloader() {
   log "Running write_device_bootloader" "ext"
 
-  dd if="${PLTDIR}/${DEVICE}/u-boot/sunxi-spl.bin" of=${LOOP_DEV} conv=fsync bs=8k seek=1
-  dd if="${PLTDIR}/${DEVICE}/u-boot/u-boot.itb" of=${LOOP_DEV} conv=fsync bs=8k seek=5
+  dd if="${PLTDIR}/${DEVICE}/u-boot/sunxi-spl.bin" of="${LOOP_DEV}" conv=fsync bs=8k seek=1
+  dd if="${PLTDIR}/${DEVICE}/u-boot/u-boot.itb" of="${LOOP_DEV}" conv=fsync bs=8k seek=5
 }
 
 # Will be called by the image builder for any customisation
 device_image_tweaks() {
-  :  
+  :
 }
 
 # Will be run in chroot - Pre initramfs
 device_chroot_tweaks_pre() {
   log "Performing device_chroot_tweaks_pre" "ext"
-  log "Update fstab with UUIDs"
-  sed -i "s_/dev/mmcblk0p1_UUID=${UUID_BOOT}_" /etc/fstab
 
   log "Modify uEnv.txt template"
   sed -i "s/%%BOOT-SD%%/rebootmode=file bootdev=mmcblk0 bootpart=\/dev\/mmcblk0p1 imgpart=\/dev\/mmcblk0p2 datapart=\/dev\/mmcblk0p3/g" /boot/uEnv.txt
   sed -i "s/%%BOOT-EMMC%%/rebootmode=file bootdev=mmcblk2 bootpart=\/dev\/mmcblk2p1 imgpart=\/dev\/mmcblk2p2 datapart=\/dev\/mmcblk2p3/g" /boot/uEnv.txt
 
   log "Fixing armv8 deprecated instruction emulation with armv7 rootfs"
-  cat <<-EOF >> /etc/sysctl.conf
-abi.cp15_barrier=2
-EOF
+  cat <<-EOF >>/etc/sysctl.conf
+	abi.cp15_barrier=2
+	EOF
 
   log "Enabling Bluetooth Adapter auto-poweron"
-  cat <<-EOF > /etc/bluetooth/main.conf
-[Policy]
-AutoEnable=true
-EOF 
+  cat <<-EOF >/etc/bluetooth/main.conf
+	[Policy]
+	AutoEnable=true
+	EOF
 
   log "Installing tslib for ts calibration purposes"
-  dpkg -i -f noninteractive /libts0_1.19-1_armhf.deb 
+  dpkg -i -f noninteractive /libts0_1.19-1_armhf.deb
   dpkg -i /libts-bin_1.19-1_armhf.deb
 
   log "Cleanup unused .debs"
@@ -125,23 +124,23 @@ EOF
   rm xf86-video-fbturbo_1.00-1_armhf.deb
 
   log "Adding motivo-specific counter-clockwise screen rotation"
-  cat <<-EOF > /etc/X11/xorg.conf
-Section "Device"
-  Identifier "LCD"
-  Driver "fbturbo"
-  Option "fbdev" "/dev/fb0"
-  Option "Rotate" "CCW"
-  Option "SwapbuffersWait" "true"
-  Option "HWCursor" "false"
-  Option "RandRRotation" "on"
-EndSection
-
-Section "InputClass"
-  Identifier   "calibration"
-  MatchProduct "Goodix Capacitive TouchScreen"
-  Option       "Calibration" "0 1280 0 800"
-EndSection
-EOF
+  cat <<-EOF >/etc/X11/xorg.conf
+	Section "Device"
+	  Identifier "LCD"
+	  Driver "fbturbo"
+	  Option "fbdev" "/dev/fb0"
+	  Option "Rotate" "CCW"
+	  Option "SwapbuffersWait" "true"
+	  Option "HWCursor" "false"
+	  Option "RandRRotation" "on"
+	EndSection
+	
+	Section "InputClass"
+	  Identifier   "calibration"
+	  MatchProduct "Goodix Capacitive TouchScreen"
+	  Option       "Calibration" "0 1280 0 800"
+	EndSection
+	EOF
 
 }
 

--- a/recipes/devices/odroidn2.sh
+++ b/recipes/devices/odroidn2.sh
@@ -26,6 +26,7 @@ KIOSKMODE=no
 BOOT_START=1
 BOOT_END=64
 BOOT_TYPE=msdos          # msdos or gpt
+BOOT_USE_UUID=yes        # Add UUID to fstab
 INIT_TYPE="init.nextarm" # init.{x86/nextarm/nextarm_tvbox}
 
 # Modules that will be added to intramsfs
@@ -60,22 +61,20 @@ write_device_bootloader() {
 
 # Will be called by the image builder for any customisation
 device_image_tweaks() {
-  :  
+  :
 }
 
 # Will be run in chroot - Pre initramfs
 device_chroot_tweaks_pre() {
   log "Performing device_chroot_tweaks_pre" "ext"
-  log "Update fstab with UUIDs"
-  sed -i "s_/dev/mmcblk0p1_UUID=${UUID_BOOT}_" /etc/fstab
 
   log "Creating boot.ini from template"
   sed -i "s/%%VOLUMIO-PARAMS%%/imgpart=UUID=${UUID_IMG} imgfile=\/volumio_current.sqsh hwdevice=Odroid-N2 bootpart=UUID=${UUID_BOOT} datapart=UUID=${UUID_DATA} bootconfig=boot.ini loglevel=0/" /boot/boot.ini
 
   log "Fixing armv8 deprecated instruction emulation with armv7 rootfs"
-  cat <<-EOF >> /etc/sysctl.conf
-abi.cp15_barrier=2
-EOF
+  cat <<-EOF >>/etc/sysctl.conf
+	abi.cp15_barrier=2
+	EOF
 
 }
 

--- a/recipes/devices/orangepilite.sh
+++ b/recipes/devices/orangepilite.sh
@@ -66,8 +66,8 @@ device_chroot_tweaks_pre() {
   usermod -aG gpio volumio
   # Works with newer kernels as well
   cat <<-EOF >/etc/udev/rules.d/99-gpio.rules
-SUBSYSTEM=="gpio*", PROGRAM="/bin/sh -c 'find -L /sys/class/gpio/ -maxdepth 2 -exec chown root:gpio {} \; -exec chmod 770 {} \; || true'"
-EOF
+	SUBSYSTEM=="gpio*", PROGRAM="/bin/sh -c 'find -L /sys/class/gpio/ -maxdepth 2 -exec chown root:gpio {} \; -exec chmod 770 {} \; || true'"
+	EOF
   # touch /etc/udev/rules.d/99-gpio.rules
   # echo "SUBSYSTEM==\"gpio\", ACTION==\"add\", RUN=\"/bin/sh -c '
   #         chown -R root:gpio /sys/class/gpio && chmod -R 770 /sys/class/gpio;\


### PR DESCRIPTION
By setting `BOOT_USE_UUID=yes` in the device file, `makeimage` sets the `BOOT_FS_SPEC` to use the UUID (instead of default `/dev/mmcblk0p1`) that is then later written to the fstab by `chrootconfig`   https://github.com/volumio/Build/blob/df8342796ea597e131cfe23ecc7c7ff2bd30c74d/scripts/makeimage.sh#L183-L185
https://github.com/volumio/Build/blob/df8342796ea597e131cfe23ecc7c7ff2bd30c74d/scripts/volumio/chrootconfig.sh#L25-L31

Also found a few copypasta syntax issues that were preventing builds, and for good measure ran a formatter on everything to catch the rest. :-)

I had set up a [CI to catch these things back on `ashthespy/VolumioOS`](https://github.com/ashthespy/VolumioOS/runs/1670528502?check_suite_focus=true#step:3:97) --  will also try and set up an auto formatter so we don't get bitten by whitespace issues..
