### PR TITLE
added PasswordAuthentication in sshd_config

### DIFF
--- a/volumio/etc/ssh/sshd_config
+++ b/volumio/etc/ssh/sshd_config
@@ -16,6 +16,7 @@ PubkeyAuthentication yes
 IgnoreRhosts yes
 RhostsRSAAuthentication no
 HostbasedAuthentication no
+PasswordAuthentication yes
 PermitEmptyPasswords no
 ChallengeResponseAuthentication no
 X11Forwarding yes


### PR DESCRIPTION
very important parameter for safety. let it be set to "yes" by default, and if desired, it can be set to "no" by adding your key