### PR TITLE
Tweak error handling for device script functions.

### DIFF
--- a/recipes/devices/families/kvims.sh
+++ b/recipes/devices/families/kvims.sh
@@ -42,8 +42,6 @@ PACKAGES=("u-boot-tools" "lirc" "fbset" "mc" "abootimg" "bluez-firmware"
 # Copy the device specific files (Image/DTS/etc..)
 write_device_files() {
 
-  trap exit_error INT ERR
-
   log "Running write_device_files" "ext"
 
   cp -R "${PLTDIR}/${DEVICEBASE}/boot" "${ROOTFSMNT}"
@@ -110,8 +108,6 @@ write_device_files() {
 }
 
 write_device_bootloader() {
-
-  trap exit_error INT ERR
 
   log "Running write_device_bootloader u-boot.$BOARD.sd.bin" "ext"
 

--- a/recipes/devices/families/x86.sh
+++ b/recipes/devices/families/x86.sh
@@ -61,7 +61,6 @@ PACKAGES=(
 ### Device customisation
 # Copy the device specific files (Image/DTS/etc..)
 write_device_files() {
-  trap exit_error INT ERR
   log "Running write_device_files" "ext"
   log "Copying kernel files"
   pkg_root="${PLTDIR}/packages-buster"
@@ -106,7 +105,6 @@ write_device_files() {
 }
 
 write_device_bootloader() {
-  trap exit_error INT ERR
   log "Running write_device_bootloader" "ext"
   log "Copying the Syslinux boot sector"
   dd conv=notrunc bs=440 count=1 if="${ROOTFSMNT}"/usr/lib/syslinux/mbr/gptmbr.bin of="${LOOP_DEV}"

--- a/recipes/devices/odroidn2.sh
+++ b/recipes/devices/odroidn2.sh
@@ -37,7 +37,6 @@ PACKAGES=("u-boot-tools" "lirc" "fbset")
 ### Device customisation
 # Copy the device specific files (Image/DTS/etc..)
 write_device_files() {
-  trap exit_error INT ERR
   log "Running write_device_files" "ext"
 
   cp -dR "${PLTDIR}/${DEVICE}/boot" "${ROOTFSMNT}"
@@ -55,7 +54,6 @@ write_device_files() {
 }
 
 write_device_bootloader() {
-  trap exit_error INT ERR
   log "Running write_device_bootloader" "ext"
 
   dd if="${PLTDIR}/${DEVICE}/uboot/u-boot.bin" of="${LOOP_DEV}" conv=fsync,notrunc bs=512 seek=1

--- a/scripts/helpers.sh
+++ b/scripts/helpers.sh
@@ -62,12 +62,12 @@ log() {
 		;;
 
 	"")
-		echo -e "[${green} $char ${normal}] $1 $tmp "
+		echo -e "[${green} $char ${normal}] $1 $tmp"
 		;;
 
 	*)
 		[[ -n $2 ]] && tmp="[${yellow} $2 ${normal}]"
-		echo -e "[${green} .. ${normal}] $1 $tmp "
+		echo -e "[${green} $char ${normal}] $1 $tmp"
 		;;
 
 	esac

--- a/scripts/volumio/chrootconfig.sh
+++ b/scripts/volumio/chrootconfig.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 set -eo pipefail
-
+set -o errtrace
 # This script will be run in chroot under qemu.
 # Re import helpers in chroot
 # shellcheck source=./scripts/helpers.sh
@@ -15,7 +15,8 @@ export -f time_it
 source /chroot_device_config.sh
 
 function exit_error() {
-  log "Volumio chroot config failed" "$(basename "$0")" "err"
+  log "Volumio chroot config failed" "err" "$(basename "$0")"
+  log "Error stack $(printf '[%s] <= ' "${FUNCNAME[@]:1}")" "err" "$(caller)"
 }
 
 trap exit_error INT ERR


### PR DESCRIPTION
Building upon the discussion in db7b9568d6b7115d39086b3ea4311bedb99cb4c9, tweaked the error handling for our device template functions. 
Errors in `device_chroot_xxx` device functions were caught previously because `chroot` would propagate any error up catch the trap.  But device functions like `write_device_xx` wouldn't given the way Bash handles functions environments by default. 
We now set the  `-o errtrace` flag to explicitly force errors in functions to catch traps as well.

Also tried to have the errors be a little more informative to quickly track down where they arise. The stack trace is quite  rudimentary - it isn't the best (even worse inside `chroot`), but it is something ;-) 


Some tests: 
```diff
diff --git a/recipes/devices/families/kvims.sh b/recipes/devices/families/kvims.sh
index 2834189..d20c32c 100644
--- a/recipes/devices/families/kvims.sh
+++ b/recipes/devices/families/kvims.sh
@@ -50,6 +50,9 @@ write_device_files() {
   rm "${ROOTFSMNT}/boot/aml_autoscript"
   rm "${ROOTFSMNT}/boot/aml_autoscript.cmd"
 
+  log "Testing error traps"
+  cp "this/path/should/throw/an/error" "${ROOTFSMNT}/boot"
+
   log "Retain copies of u-boot files for Volumio Updater"
   cp -r "${PLTDIR}/${DEVICEBASE}/uboot" "${ROOTFSMNT}/boot"
   cp -r "${PLTDIR}/${DEVICEBASE}/uboot-mainline" "${ROOTFSMNT}/boot"
```

```
[ .... ] Copying Volumio rootfs  
[ .. ] Creating Volumio Temp Directory 
[ .. ] Creating mount point for the images partition 
[ .... ] Copying Volumio RootFs  
[ .... ] Getting device specific files for mp1 from platform-khadas  
[ .. ] Platform folder exists, keeping it [ platform-khadas ]
[ .... ] Copying mp1 boot files from platform-khadas/vims.tar.xz  
[ cfg ] Entering write_device_files 
[ .. ] Running write_device_files [ ext ]
[ .. ] AML autoscripts not for Volumio 
[ .. ] Testing error traps 
cp: cannot stat 'this/path/should/throw/an/error': No such file or directory
[ error ] Imagebuilder script failed!! 
[ error ] Error stack [write_device_files] <= [source] <= [main] <=  [ 53 /Build/recipes/devices/families/kvims.sh ]
[ .. ] Cleaning up image_tmp mounts 
[ .. ] Cleaning loop device /dev/loop26 [ /dev/loop26: [2065]:2109151 (/Build/Build_2021-01-11_15-56-33/Volumio-0.00-2021-01-11-mp1.img) ]
[ .. ] Deleting image file 
```

And inside chroot
```diff
diff --git a/recipes/devices/families/kvims.sh b/recipes/devices/families/kvims.sh
index 2834189..4eb8c67 100644
--- a/recipes/devices/families/kvims.sh
+++ b/recipes/devices/families/kvims.sh
@@ -124,6 +124,8 @@ device_image_tweaks() {
 # Will be run in chroot - Pre initramfs
 device_chroot_tweaks_pre() {
   log "Performing device_chroot_tweaks_pre" "ext"
+  log "Testing error traps (chroot)"
+  cp "this/path/should/throw/an/erro/inside/chroot" "${ROOTFSMNT}/boot"
 
   log "Creating boot parameters from template"
   sed -i "s/#imgpart=UUID=/imgpart=UUID=${UUID_IMG}/g" /boot/env.system.txt
```

```
Setting up bluez-obexd (5.50-1.2~deb10u1) ...
Processing triggers for mime-support (3.62) ...
Processing triggers for hicolor-icon-theme (0.17-2) ...
Processing triggers for libc-bin (2.28-10) ...
Processing triggers for systemd (241-7~deb10u5) ...
Processing triggers for dbus (1.12.20-0+deb10u1) ...
[ cfg ] Entering device_chroot_tweaks_pre 
[ .. ] Performing device_chroot_tweaks_pre [ ext ] 
[ -- ] Testing error traps (chroot)  
/bin/cp: cannot stat 'this/path/should/throw/an/erro/inside/chroot': No such file or directory
[ error ] Volumio chroot config failed [ chrootconfig.sh ]
[ error ] Error stack [device_chroot_tweaks_pre] <= [main] <=  [ 21 /chroot_device_config.sh ]
[ error ] Imagebuilder script failed!! 
[ error ] Error stack [source] <= [main] <=  [ 218 /Build/scripts/makeimage.sh ]
[ -- ] Cleaning up image_tmp mounts 
[ -- ] Unmounting chroot temporary devices at /mnt/volumio/rootfs 
[ .. ] Cleaning loop device /dev/loop26 [ /dev/loop26: [2065]:2109153 (/Build/Build_2021-01-11_15-58-36/Volumio-0.00-2021-01-11-mp1.img) ]
[ .. ] Deleting image file 
```


