### PR TITLE
Triggerhappy instead of xbindkeys for media controls

### DIFF
--- a/recipes/base/VolumioBase.conf
+++ b/recipes/base/VolumioBase.conf
@@ -77,7 +77,7 @@ components=main non-free
 suite=buster
 
 [Accessories]
-packages=autossh libcec4 lsb-release xbindkeys
+packages=autossh libcec4 lsb-release triggerhappy
 source=https://deb.debian.org/debian
 keyring=debian-archive-keyring
 suite=buster

--- a/scripts/volumio/configure.sh
+++ b/scripts/volumio/configure.sh
@@ -114,4 +114,7 @@ chmod a+x "${ROOTFS}/bin/volumio_cpu_tweak"
 #LAN HOTPLUG
 cp "${SRC}/volumio/etc/default/ifplugd" "${ROOTFS}/etc/default/ifplugd"
 
+#TRIGGERHAPPY
+cp "${SRC}/volumio/etc/triggerhappy/triggers.d/audio.conf" "${ROOTFS}/etc/triggerhappy/triggers.d/audio.conf"
+
 log 'Done Copying Custom Volumio System Files' "okay"

--- a/scripts/volumio/volumioconfig.sh
+++ b/scripts/volumio/volumioconfig.sh
@@ -453,27 +453,4 @@ rm -f /etc/avahi/services/udisks.service
 log "Setting CPU governor to performance" "info"
 echo 'GOVERNOR="performance"' >/etc/default/cpufrequtils
 
-#####################
-#Multimedia Keys#-----------------------------------------
-#####################
-
-log "Configuring xbindkeys"
-cat <<-EOF >/etc/xbindkeysrc
-"/usr/local/bin/volumio toggle"
-    XF86AudioPlay
-"/usr/local/bin/volumio previous"
-    XF86AudioPrev
-"/usr/local/bin/volumio next"
-    XF86AudioNext
-"/usr/local/bin/volumio volume toggle"
-    XF86AudioMute
-"/usr/local/bin/volumio volume minus"
-    XF86AudioLowerVolume
-"/usr/local/bin/volumio volume plus"
-XF86AudioRaiseVolume'
-EOF
-
-# log "Enabling xbindkeys"
-# ln -s /lib/systemd/system/xbindkeysrc.service /etc/systemd/system/multi-user.target.wants/xbindkeysrc.service
-
 log "Finished Volumio chroot configuration for ${DISTRO_NAME}" "okay"

--- a/volumio/etc/triggerhappy/triggers.d/audio.conf
+++ b/volumio/etc/triggerhappy/triggers.d/audio.conf
@@ -1,0 +1,20 @@
+#VOLUMIO TRIGGERHAPPY CONFIGURATION FILE
+
+#MUTE TOGGLE
+KEY_MIN_INTERESTING 1 /usr/local/bin/volumio volume toggle
+
+#VOLUME UP
+KEY_VOLUMEUP 1 /usr/local/bin/volumio volume plus
+
+#VOLUME DOWN
+KEY_VOLUMEDOWN 1 /usr/local/bin/volumio volume minus
+
+#PLAY PAUSE TOGGLE
+KEY_PLAYPAUSE 1 /usr/local/bin/volumio toggle
+
+#NEXT
+KEY_NEXTSONG 1 /usr/local/bin/volumio next
+
+#PREVIOUS
+KEY_PREVIOUSSONG 1 /usr/local/bin/volumio previous
+


### PR DESCRIPTION
Cherry picked 859858f6eee0b4de0db7aa9e3dc878e08afe0fa3 into our tree..

Not sure which devices use it -- please do test! :-)


Fixes #386 (in new build that is)