### PR TITLE
Use deb.debian.org instead of httpredir.d.o

### DIFF
--- a/scripts/config.sh
+++ b/scripts/config.sh
@@ -12,7 +12,7 @@ declare -A SecureApt=(
 
 # Repo locations that are utilised to create source.list in the rootfs
 declare -A APTSOURCE=(
-  [Debian]="http://httpredir.debian.org/debian"
+  [Debian]="http://deb.debian.org/debian"
   [Raspbian]="http://raspbian.raspberrypi.org/raspbian/"
 )
 

--- a/volumio/etc/apt/sources.list.arm
+++ b/volumio/etc/apt/sources.list.arm
@@ -1,2 +1,0 @@
-deb http://raspbian.raspberrypi.org/raspbian/ buster main contrib non-free rpi
-deb-src http://raspbian.raspberrypi.org/raspbian/ buster main contrib non-free rpi

--- a/volumio/etc/apt/sources.list.armv7
+++ b/volumio/etc/apt/sources.list.armv7
@@ -1,2 +1,0 @@
-deb http://deb.debian.org/debian buster main contrib non-free
-deb-src http://deb.debian.org/debian buster main contrib non-free

--- a/volumio/etc/apt/sources.list.armv7
+++ b/volumio/etc/apt/sources.list.armv7
@@ -1,2 +1,2 @@
-deb http://httpredir.debian.org/debian buster main contrib non-free
-deb-src http://httpredir.debian.org/debian buster main contrib non-free
+deb http://deb.debian.org/debian buster main contrib non-free
+deb-src http://deb.debian.org/debian buster main contrib non-free

--- a/volumio/etc/apt/sources.list.armv8
+++ b/volumio/etc/apt/sources.list.armv8
@@ -1,2 +1,0 @@
-deb http://deb.debian.org/debian buster main contrib non-free
-deb-src http://deb.debian.org/debian buster main contrib non-free

--- a/volumio/etc/apt/sources.list.armv8
+++ b/volumio/etc/apt/sources.list.armv8
@@ -1,2 +1,2 @@
-deb http://httpredir.debian.org/debian buster main contrib non-free
-deb-src http://httpredir.debian.org/debian buster main contrib non-free
+deb http://deb.debian.org/debian buster main contrib non-free
+deb-src http://deb.debian.org/debian buster main contrib non-free

--- a/volumio/etc/apt/sources.list.x86
+++ b/volumio/etc/apt/sources.list.x86
@@ -1,2 +1,0 @@
-deb http://deb.debian.org/debian buster main contrib non-free
-deb-src http://deb.debian.org/debian buster main contrib non-free

--- a/volumio/etc/apt/sources.list.x86
+++ b/volumio/etc/apt/sources.list.x86
@@ -1,2 +1,2 @@
-deb http://httpredir.debian.org/debian buster main contrib non-free
-deb-src http://httpredir.debian.org/debian buster main contrib non-free
+deb http://deb.debian.org/debian buster main contrib non-free
+deb-src http://deb.debian.org/debian buster main contrib non-free


### PR DESCRIPTION
https://wiki.debian.org/DebianGeoMirror states that httpredir has been discontinued.

I've tested this only by building a volumio image; not sure what further testing is required.