### PR TITLE
 Add BE precommit hooks

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -119,6 +119,12 @@ function fetch_volumio_from_repo() {
     log "Setting BE_REPO to commit" "${VOL_BE_REPO_SHA}"
     git -C "${ROOTFS}/volumio/" reset --hard "${VOL_BE_REPO_SHA}"
   fi
+  log "Adding precommit hooks"
+  cat <<-EOF >"${ROOTFS}/volumio/.git/hooks/pre-commit"
+	#!/bin/bash
+	# Pre-commit hook, uncomment when finished linting all codebase
+	#npm run lint-staged
+	EOF
 
   log "Adding wireless.js"
   cp "${SRC}/volumio/bin/wireless.js" "${ROOTFS}/volumio/app/plugins/system_controller/network/wireless.js"


### PR DESCRIPTION
Added the lint hooks back..

However, today I think it might be easier/nicer to instead setup a simple CI that formats all PRs.. Instead of getting contributors to mess with white space.. 


On a side note - I see I set my soft tabs to 2 spaces. Resulting in what the build scripts look like. Do you want me to change to 4?