### PR TITLE
Cleanup rootfs

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -310,7 +310,7 @@ if [ -n "${BUILD}" ]; then
   log "Creating ${BUILD} rootfs" "info"
   #TODO Check naming conventions!
   BASE="Debian"
-  if [[ ! -f "$SUITE" ]]; then
+  if [[ -z "$SUITE" ]]; then
     log "Defaulting to release" "" "Buster"
     SUITE="buster"
   fi

--- a/recipes/base/VolumioBase.conf
+++ b/recipes/base/VolumioBase.conf
@@ -16,7 +16,7 @@ aptpreferences=/etc/apt/apt.conf.d/01progress
 
 #TODO: Prune and organise these packages!
 [Base]
-packages=acl apt apt-transport-https base-files base-passwd bash busybox debconf debconf-i18n debian-archive-keyring debianutils dmsetup e2fslibs e2fsprogs gcc-8-base gnupg gpgv initscripts insserv
+packages=acl apt base-files base-passwd bash busybox debconf debconf-i18n debian-archive-keyring debianutils dmsetup e2fsprogs gcc-8-base gnupg gpgv initscripts insserv
 packages=lsb-base mawk multiarch-support ncurses-base ncurses-bin procps readline-common startpar sudo systemd tzdata udev util-linux xz-utils zlib1g
 # Libraries
 # packages=libacl1 libapt-pkg5.0 libattr1 libaudit-common libaudit1 libblkid1 libbz2-1.0 libc-bin libc6 libcap2 libcap2-bin libcomerr2 libcryptsetup12 libdb5.3 libdebconfclient0 libdevmapper1.02.1 libgcc1
@@ -45,7 +45,7 @@ keyring=debian-archive-keyring
 suite=buster
 
 [Utils]
-packages=avahi-daemon bc ca-certificates cpufrequtils curl ethtool fake-hwclock git haveged i2c-tools jq less localepurge locales md5deep minizip nano ntp parted policykit-1
+packages=avahi-daemon bc ca-certificates cpufrequtils curl ethtool fake-hwclock git hashdeep haveged i2c-tools jq less localepurge locales minizip nano ntp parted policykit-1
 packages=psmisc rsync strace usbutils wget zsync
 # Libraries
 packges=libnss-mdns
@@ -62,7 +62,9 @@ keyring=debian-archive-keyring
 suite=buster
 
 [Assets]
-packages=alsa-utils python-requests shairport-sync sox sqlite3
+packages=alsa-utils shairport-sync sox sqlite3
+# Is this required?
+# packages=python-requests 
 # Libraries
 packages=libasound2 libasound2-plugins
 # packages=libconfig-dev
@@ -72,7 +74,7 @@ keyring=debian-archive-keyring
 suite=buster
 
 [Firmware]
-packages=firmware-atheros firmware-brcm80211 firmware-linux-free firmware-ralink firmware-realtek
+packages=firmware-atheros firmware-brcm80211 firmware-linux-free firmware-realtek
 source=http://deb.debian.org/debian
 keyring=debian-archive-keyring
 components=main non-free
@@ -106,7 +108,6 @@ suite=buster
 
 [Volumio]
 packages=mpc mpd 
-# packags=zsync
 source=http://deb.debian.org/debian
 keyring=debian-archive-keyring
 suite=buster

--- a/recipes/base/VolumioBase.conf
+++ b/recipes/base/VolumioBase.conf
@@ -19,9 +19,9 @@ aptpreferences=/etc/apt/apt.conf.d/01progress
 packages=acl apt apt-transport-https base-files base-passwd bash busybox debconf debconf-i18n debian-archive-keyring debianutils dmsetup e2fslibs e2fsprogs gcc-8-base gnupg gpgv initscripts insserv
 packages=lsb-base mawk multiarch-support ncurses-base ncurses-bin procps readline-common startpar sudo systemd tzdata udev util-linux xz-utils zlib1g
 # Libraries
-packages=libacl1 libapt-pkg5.0 libattr1 libaudit-common libaudit1 libblkid1 libbz2-1.0 libc-bin libc6 libcap2 libcap2-bin libcomerr2 libcryptsetup12 libdb5.3 libdebconfclient0 libdevmapper1.02.1 libgcc1
-packages=libgcrypt20 libgpg-error0 libkmod2 liblzma5 libmount1 libncurses5 libncursesw5 libpam-modules libpam-modules-bin libpam-runtime libpam0g libpcre3 libprocps7 libreadline7 libselinux1 libsemanage-common
-packages=libsemanage1 libsepol1 libslang2 libsmartcols1 libss2 libstdc++6 libsystemd0 libtinfo5 libudev1 libusb-0.1-4 libustr-1.0-1 libuuid1
+# packages=libacl1 libapt-pkg5.0 libattr1 libaudit-common libaudit1 libblkid1 libbz2-1.0 libc-bin libc6 libcap2 libcap2-bin libcomerr2 libcryptsetup12 libdb5.3 libdebconfclient0 libdevmapper1.02.1 libgcc1
+# packages=libgcrypt20 libgpg-error0 libkmod2 liblzma5 libmount1 libncurses5 libncursesw5 libpam-modules libpam-modules-bin libpam-runtime libpam0g libpcre3 libprocps7 libreadline7 libselinux1 libsemanage-common
+# packages=libsemanage1 libsepol1 libslang2 libsmartcols1 libss2 libstdc++6 libsystemd0 libtinfo5 libudev1 libusb-0.1-4 libustr-1.0-1 libuuid1
 source=http://deb.debian.org/debian
 keyring=debian-archive-keyring
 suite=buster
@@ -30,7 +30,7 @@ suite=buster
 [BaseDebPlus]
 packages=cpio initramfs-tools klibc-utils makedev pigz plymouth
 # Libraries
-packages=libdrm2 libklibc
+# packages=libdrm2 libklibc
 source=http://deb.debian.org/debian
 keyring=debian-archive-keyring
 suite=buster
@@ -38,13 +38,14 @@ suite=buster
 [Net]
 packages=crda dhcpcd5 dnsmasq ethtool hostapd ifplugd ifupdown iproute2 iptables iputils-ping iw net-tools netbase openssh-server rfkill telnet wireless-regdb wireless-tools wpasupplicant
 # Libraries
-packages=libavahi-compat-libdnssd-dev libgnutls-openssl* libnl-3-200 libnl-genl-3-200 libpcsclite1
+packages=libavahi-compat-libdnssd-dev 
+# packages=libgnutls-openssl* libnl-3-200 libnl-genl-3-200 libpcsclite1
 source=http://deb.debian.org/debian
 keyring=debian-archive-keyring
 suite=buster
 
 [Utils]
-packages=avahi-daemon avahi-discover bc ca-certificates cpufrequtils curl ethtool fake-hwclock git haveged i2c-tools jq less localepurge locales md5deep minizip nano ntp parted policykit-1
+packages=avahi-daemon bc ca-certificates cpufrequtils curl ethtool fake-hwclock git haveged i2c-tools jq less localepurge locales md5deep minizip nano ntp parted policykit-1
 packages=psmisc rsync strace usbutils wget zsync
 # Libraries
 packges=libnss-mdns
@@ -53,9 +54,9 @@ keyring=debian-archive-keyring
 suite=buster
 
 [FS]
-packages=cifs-utils dosfstools exfat-fuse exfat-utils nfs-common ntfs-3g samba smbclient udevil winbind
+packages=cifs-utils dosfstools exfat-fuse exfat-utils nfs-common ntfs-3g samba smbclient winbind
 # Libraries
-packages=libnss-winbind
+# packages=libnss-winbind
 source=http://deb.debian.org/debian
 keyring=debian-archive-keyring
 suite=buster
@@ -63,8 +64,9 @@ suite=buster
 [Assets]
 packages=alsa-utils python-requests shairport-sync sox sqlite3
 # Libraries
-packages=libasound2 libasound2-data libasound2-plugins libconfig-dev libcurl4 libexpat1 libexpat1 libjsoncpp1
-packages=libmicrohttpd12 libmpdclient2 libsidplayfp4 libupnp13
+packages=libasound2 libasound2-plugins
+# packages=libconfig-dev
+# packages=libmicrohttpd12 libmpdclient2 libsidplayfp4 libupnp13
 source=http://deb.debian.org/debian
 keyring=debian-archive-keyring
 suite=buster
@@ -103,7 +105,8 @@ keyring=debian-archive-keyring
 suite=buster
 
 [Volumio]
-packages=mpc mpd zsync
+packages=mpc mpd 
+# packags=zsync
 source=http://deb.debian.org/debian
 keyring=debian-archive-keyring
 suite=buster

--- a/scripts/makeimage.sh
+++ b/scripts/makeimage.sh
@@ -274,7 +274,7 @@ log "Creating SquashFS, removing any previous one" "info"
 [[ -f "${SRC}/Volumio.sqsh" ]] && rm "${SRC}/Volumio.sqsh"
 mksquashfs ${SQSHMNT}/* "${SRC}/Volumio.sqsh"
 
-log "Squash filesystem created" "okay"
+log "Squash filesystem created" "okay" "$(du -h0 "${SRC}/Volumio.sqsh" | cut -f1)"
 rm -rf --one-file-system $SQSHMNT
 
 log "Preparing boot partition" "info"


### PR DESCRIPTION
### Changes
-- Removing a lot of redundant multistrap config bits (like libraries, dummy packages) 
since we don't set [`omitrequired=true`](https://manpages.debian.org/testing/multistrap/multistrap.1.en.html#Restricting_package_selection), we can remove the libraries that are linked to installed packages.
>If the OmitRequired option is set to true, these packages will not be added - whilst useful, this option can easily lead to a useless rootfs. Only the packages specified manually in the configuration files will be used in the calculations - dependencies of those packages will be added but no others.

This then leaves extra libs that are really needed.  e.g `libavahi-compat-libdnssd-dev` for the [`mdns`](https://www.npmjs.com/package/mdns#installation) node package utilised by the back end. Ideally would like to move these all to a new section, to make tracking dependencies simpler. 
Currently we don't really know/recall what is required for what..

-- Removed some packages 
--- [`avahi-discover`](https://packages.debian.org/buster/avahi-discover) as we don't need the graphical browser.
--- [`udevil`](https://packages.debian.org/buster/udevil) as USB auto-mount is done using [`node-udev`](https://www.npmjs.com/package/udev)
---[`pyhton-requests`](https://packages.debian.org/buster/python-requests) not really sure what it was being used for?

There are quite a few more, like [`sqlite3`](https://packages.debian.org/buster/sqlite3) that [seems to be removed in the back-end](https://github.com/volumio/Volumio2/commit/2223fc5bbb64b8ad0a6348b3ca8c3c036fa01385) but still remain here, but I guess it's better to discuss/track these in #429 

--Streamline and log sizes of the rootfs so we see how it grows/shrinks.

N.B: All our custom `dpkg.cfg.d/` rules are not in place when we run multistrap, and I tried playing around getting multistrap to honour them, but didn't succeed. So all the `--path-exclude` stuff is only valid for installs that are done in chroot later on.. It would be great to not extract everything first, and then delete it in `finalize.sh`. Minor optimisation, but should think about it..

