### PR TITLE
Synchronise device scripts

### DIFF
--- a/recipes/devices/README.MD
+++ b/recipes/devices/README.MD
@@ -35,14 +35,14 @@ Most devices rely on the community to test, debug and maintain :-)
 
 #### Device Support Type `[C|S|O]`
 
-C = Community porting
-S = Officially Supported device
-O = OEM or Volumio internal use
+C = Community porting<br>
+S = Officially Supported device<br>
+O = OEM or Volumio internal use<br>
 
 #### Device Status `[P|T|M]`
 
-P = Planned
-T = Testing
-M = Maintained
+P = Planned<br>
+T = Testing<br>
+M = Maintained<br>
 
 

--- a/recipes/devices/README.MD
+++ b/recipes/devices/README.MD
@@ -7,43 +7,42 @@ Most devices rely on the community to test, debug and maintain :-)
 
 | Device       | Base  | Arch  | `VOLUMIO_DEVICENAME` | `VOLUMIO_DEVICENAME` | Kernel                                                     | Type | Status |
 | ------------ | ----- | ----- | -------------------- | -------------------- | ---------------------------------------------------------- | ---- | ------ |
-| cuboxp       | armv7 | armhf | cuboxp               | Cubox Pulse          | [4.14.y](https://github.com/gkkpch/platform-cubox.git)     | C    |    P   |
-| kvim1        | armv7 | armhf | kvim1                | Khadas VIM1          | [4.9.y](https://github.com/volumio/platform-khadas.git)    | C    |    P   |
-| kvim2        | armv7 | armhf | kvim2                | Khadas VIM2          | [4.9.y](https://github.com/volumio/platform-khadas.git)    | C    |    P   |
-| kvim3        | armv7 | armhf | kvim3                | Khadas VIM3          | [4.9.y](https://github.com/volumio/platform-khadas.git)    | C    |    P   |
-| motivo       | armv7 | armhf | motivo               | Volumio Motivo       | [5.7.y](https://github.com/volumio/platform-motivo.git)    | O    |    T   |
-| mp1          | armv7 | armhf | mp1                  | Volumio Rivo         | [4.9.y](https://github.com/volumio/platform-khadas.git)    | O    |    T   |
-| nanopineo2   | armv8 | arm64 | nanopineo2           | NanoPi Neo2          | [5.4.y](https://github.com/ashthespy/platform-nanopi)      | C    |    P   |
-| nanopineo2   | armv7 | arm64 | nanopineo2           | NanoPi Neo2          | [4.11.y](https://github.com/volumio/platform-nanopi)       | C, O |    P   |
-| nanopineo3   | armv7 | armhf | nanopineo3           | Nanopi Neo3          | [5.4.y](https://github.com/volumio/platform-nanopi.git)    | C, O |    T   |
-| odroidc1     | armv7 | armhf | odroidc1             | Odroid-C1            | [3.10.y](https://github.com/volumio/platform-odroid.git)   | C    |    P   |
-| odroidc2     | armv7 | armhf | odroidc2             | Odroid-C2            | [3.16.y](https://github.com/volumio/platform-odroid.git)   | C    |    P   |
-| odroidc4     | armv7 | armhf | odroidc4             | Odroid-C4            | [4.9.y](https://github.com/volumio/platform-odroid.git)    | C    |    P   |
-| odroidn2     | armv7 | armhf | odroidn2             | Odroid-N2            | [4.9.y](https://github.com/volumio/platform-odroid.git)    | C    |    P   |
-| odroidxu4    | armv7 | armhf | odroidxu4            | Odroid-XU4           | [4.9.y](https://github.com/volumio/platform-odroid.git)    | C    |    P   |
-| orangepilite | armv7 | armhf | orangepilite         | Orange Pi            | [5.4.y](https://github.com/ashthespy/platform-orangepi)    | C    |    T   |
-| pine64base   | armv7 | armhf | pine64               | Pine64               | [5.7.y](https://github.com/volumio/platform-pine64.git)    | C    |    P   |
-| pine64plus   | armv7 | armhf | pine64plus           | Pine64+              | [5.7.y](https://github.com/volumio/platform-pine64.git)    | C    |    P   |
-| pine64solts  | armv7 | armhf | pine64solts          | soPine64-Pine64LTS   | [5.7.y](https://github.com/volumio/platform-pine64.git)    | C    |    P   |
-| pi           | arm   | armhf | pi                   | Raspberry Pi         | [5.10.y](https://github.com/raspberrypi/linux)             | S    |    T   |
-| rockpis      | armv7 | armhf | rockpis              | ROCK Pi S            | [5.6.y](https://github.com/ashthespy/platform-rockpis.git) | C    |    P   |
-| rock64       | armv7 | armhf | rock64               | ROCK64               | [4.4.y](https://github.com/volumio/platform-rock64.git)    | C    |    P   |
-| tinkerboard  | armv7 | armhf | tinkerboard          | Asus Tinkerboard     | [4.4.y](https://github.com/volumio/platform-asus.git)      | S    |    P   |
-| x86_amd64    | x64   | amd64 | x86_amd64            | x86_64               | [5.10.y](http://github.com/volumio/platform-x86)           | S    |    T   |
-| x86_i386     | x86   | i386  | x86_i386             | x86                  | [5.10.y](http://github.com/volumio/platform-x86)           | S    |    T   |
+| cuboxp       | armv7 | armhf | cuboxp               | Cubox Pulse          | [4.14.y](https://github.com/gkkpch/platform-cubox.git)     | C    | P      |
+| kvim1        | armv7 | armhf | kvim1                | Khadas VIM1          | [4.9.y](https://github.com/volumio/platform-khadas.git)    | C    | P      |
+| kvim2        | armv7 | armhf | kvim2                | Khadas VIM2          | [4.9.y](https://github.com/volumio/platform-khadas.git)    | C    | P      |
+| kvim3        | armv7 | armhf | kvim3                | Khadas VIM3          | [4.9.y](https://github.com/volumio/platform-khadas.git)    | C    | P      |
+| motivo       | armv7 | armhf | motivo               | Volumio Motivo       | [5.7.y](https://github.com/volumio/platform-motivo.git)    | O    | T      |
+| mp1          | armv7 | armhf | mp1                  | Volumio Rivo         | [4.9.y](https://github.com/volumio/platform-khadas.git)    | O    | T      |
+| nanopineo2   | armv7 | arm64 | nanopineo2           | NanoPi Neo2          | [4.11.y](https://github.com/volumio/platform-nanopi)       | C, O | P      |
+| nanopineo3   | armv7 | armhf | nanopineo3           | Nanopi Neo3          | [5.4.y](https://github.com/volumio/platform-nanopi.git)    | C, O | T      |
+| odroidc1     | armv7 | armhf | odroidc1             | Odroid-C1            | [3.10.y](https://github.com/volumio/platform-odroid.git)   | C    | P      |
+| odroidc2     | armv7 | armhf | odroidc2             | Odroid-C2            | [3.16.y](https://github.com/volumio/platform-odroid.git)   | C    | P      |
+| odroidc4     | armv7 | armhf | odroidc4             | Odroid-C4            | [4.9.y](https://github.com/volumio/platform-odroid.git)    | C    | P      |
+| odroidn2     | armv7 | armhf | odroidn2             | Odroid-N2            | [4.9.y](https://github.com/volumio/platform-odroid.git)    | C    | P      |
+| odroidxu4    | armv7 | armhf | odroidxu4            | Odroid-XU4           | [4.9.y](https://github.com/volumio/platform-odroid.git)    | C    | P      |
+| orangepilite | armv7 | armhf | orangepilite         | Orange Pi            | [5.4.y](https://github.com/ashthespy/platform-orangepi)    | C    | T      |
+| pine64base   | armv7 | armhf | pine64               | Pine64               | [5.7.y](https://github.com/volumio/platform-pine64.git)    | C    | P      |
+| pine64plus   | armv7 | armhf | pine64plus           | Pine64+              | [5.7.y](https://github.com/volumio/platform-pine64.git)    | C    | P      |
+| pine64solts  | armv7 | armhf | pine64solts          | soPine64-Pine64LTS   | [5.7.y](https://github.com/volumio/platform-pine64.git)    | C    | P      |
+| pi           | arm   | armhf | pi                   | Raspberry Pi         | [5.4.y](https://github.com/raspberrypi/linux)              | S    | T      |
+| rockpis      | armv7 | armhf | rockpis              | ROCK Pi S            | [5.6.y](https://github.com/ashthespy/platform-rockpis.git) | C    | P      |
+| rock64       | armv7 | armhf | rock64               | ROCK64               | [4.4.y](https://github.com/volumio/platform-rock64.git)    | C    | P      |
+| tinkerboard  | armv7 | armhf | tinkerboard          | Asus Tinkerboard     | [4.4.y](https://github.com/volumio/platform-asus.git)      | S    | P      |
+| vszero       | armv7 | armhf | vszero               | Voltastream Zero     | [4.1.y](https://github.com/volumio/platform-pv.git)        | C    | P      |
+| x86_amd64    | x64   | amd64 | x86_amd64            | x86_64               | [5.10.y](http://github.com/volumio/platform-x86)           | S    | T      |
+| x86_i386     | x86   | i386  | x86_i386             | x86                  | [5.10.y](http://github.com/volumio/platform-x86)           | S    | T      |
 
 
-
-Device Support Type [C|S|O]
+#### Device Support Type `[C|S|O]`
 
 C = Community porting
 S = Officially Supported device
 O = OEM or Volumio internal use
 
-Device Status [P|T|M]
+#### Device Status `[P|T|M]`
 
-P = planned
-T = testing
-M = maintain
+P = Planned
+T = Testing
+M = Maintained
 
 

--- a/recipes/devices/cuboxp.sh
+++ b/recipes/devices/cuboxp.sh
@@ -2,12 +2,11 @@
 # shellcheck disable=SC2034
 
 ## Setup for Solidrun Cubox Pulse  (Community Portings)
-DEVICE_SUPPORT_TYPE="C"   # First letter (Community Porting|Supported Officially|OEM)
-DEVICE_STATUS="P"         # First letter (Planned|Test|Maintenance)
+DEVICE_SUPPORT_TYPE="C" # First letter (Community Porting|Supported Officially|OEM)
+DEVICE_STATUS="P"       # First letter (Planned|Test|Maintenance)
 
 ## Images will not be published
 
-## WIP, this should be refactored out to a higher level.
 # Base system
 BASE="Debian"
 ARCH="armhf"
@@ -32,7 +31,7 @@ VOLINITUPDATER=yes
 BOOT_START=21
 BOOT_END=84
 BOOT_TYPE=msdos          # msdos or gpt
-BOOT_USE_UUID=yes         # Add UUID to fstab
+BOOT_USE_UUID=yes        # Add UUID to fstab
 INIT_TYPE="init.nextarm" # init.{x86/nextarm/nextarm_tvbox}
 
 # Modules that will be added to intramsfs

--- a/recipes/devices/families/kvims.sh
+++ b/recipes/devices/families/kvims.sh
@@ -3,7 +3,6 @@
 
 ## Setup for Khadas devices
 
-## WIP, this should be refactored out to a higher level.
 # Base system
 BASE="Debian"
 ARCH="armhf"

--- a/recipes/devices/families/odroids-earlygen.sh
+++ b/recipes/devices/families/odroids-earlygen.sh
@@ -3,7 +3,6 @@
 
 ## Setup for Odroid C1/C2 device (Community Portings)
 
-## WIP, this should be refactored out to a higher level.
 # Base system
 BASE="Debian"
 ARCH="armhf"
@@ -24,9 +23,9 @@ KIOSKMODE=no
 ## Partition info
 BOOT_START=1
 BOOT_END=64
-BOOT_TYPE=msdos          # msdos or gpt
-BOOT_USE_UUID=no        # Add UUID to fstab
-INIT_TYPE="init" # init.{x86/nextarm/nextarm_tvbox}
+BOOT_TYPE=msdos                           # msdos or gpt
+BOOT_USE_UUID=no                          # Add UUID to fstab
+INIT_TYPE="init"                          # init.{x86/nextarm/nextarm_tvbox}
 FLAGS_EXT4=("-O" "^metadata_csum,^64bit") # Disable ext4 metadata checksums
 
 # Modules that will be added to intramsfs
@@ -58,7 +57,7 @@ write_device_files() {
   log "Copying ${DEVICENAME} inittab"
   cp ${PLTDIR}/${DEVICEBASE}/etc/inittab ${ROOTFSMNT}/etc/
 
-#Temp Solution until init refactoring
+  #Temp Solution until init refactoring
   log "Copy early odroid init script, bypassing overlayfs syntax issues"
   cp "${PLTDIR}/${DEVICEBASE}/etc/init.odroid-earlygen" "${ROOTFSMNT}"
 

--- a/recipes/devices/families/odroids-newgen.sh
+++ b/recipes/devices/families/odroids-newgen.sh
@@ -3,7 +3,6 @@
 
 ## Setup for Odroid C4 device  (Community Portings)
 
-## WIP, this should be refactored out to a higher level.
 # Base system
 BASE="Debian"
 ARCH="armhf"

--- a/recipes/devices/families/pine64.sh
+++ b/recipes/devices/families/pine64.sh
@@ -3,14 +3,12 @@
 
 ## Setup for Pine64 family of devices  (Community Portings)
 
-## WIP, this should be refactored out to a higher level.
 # Base system
 BASE="Debian"
 ARCH="armhf"
 BUILD="armv7"
 
 ### Device information
-
 DEVICEBASE="pine64-all"
 DEVICEFAMILY="pine64"
 # This is useful for multiple devices sharing the same/similar kernel

--- a/recipes/devices/families/x86.sh
+++ b/recipes/devices/families/x86.sh
@@ -2,8 +2,6 @@
 # shellcheck disable=SC2034
 ## Setup for x86 devices
 
-## WIP: this should be refactored out to a higher level
-# Aka base config for arm,armv7,armv8 and x86
 # Base system
 BASE="Debian"
 ARCH="i386"
@@ -66,9 +64,9 @@ write_device_files() {
   pkg_root="${PLTDIR}/packages-buster"
   # Copy in the kernel version we are interested in
   # This will be expanded as a glob, you can be as specific or vague as required
-  # KERNEL_VER=4.19
-  KERNEL_VER=5.10
-  cp "${pkg_root}"/linux-image-${KERNEL_VER}*_${ARCH}.deb "${ROOTFSMNT}"
+  # KERNEL_VERSION=4.19
+  KERNEL_VERSION=5.10
+  cp "${pkg_root}"/linux-image-${KERNEL_VERSION}*_${ARCH}.deb "${ROOTFSMNT}"
   log "Copying the latest firmware into /lib/firmware"
   tar xfJ "${pkg_root}"/linux-firmware-buster.tar.xz -C "${ROOTFSMNT}"
 

--- a/recipes/devices/kvim1.sh
+++ b/recipes/devices/kvim1.sh
@@ -2,14 +2,13 @@
 # shellcheck disable=SC2034
 
 ## Setup for Khadas VIM1 board
-DEVICE_SUPPORT_TYPE="C"   # First letter (Community Porting|Supported Officially|OEM)
-DEVICE_STATUS="P"         # First letter (Planned|Test|Maintenance)
+DEVICE_SUPPORT_TYPE="C" # First letter (Community Porting|Supported Officially|OEM)
+DEVICE_STATUS="P"       # First letter (Planned|Test|Maintenance)
 
 # Import the Khadas vims configuration
 # shellcheck source=./recipes/devices/families/kvims.sh
 source "${SRC}"/recipes/devices/families/kvims.sh
 
-## WIP, this should be refactored out to a higher level.
 # Base system
 DEVICENAME="Khadas VIM1"
 DEVICE="kvim1"

--- a/recipes/devices/kvim2.sh
+++ b/recipes/devices/kvim2.sh
@@ -2,14 +2,13 @@
 # shellcheck disable=SC2034
 
 ## Setup for Khadas VIM2 board
-DEVICE_SUPPORT_TYPE="C"   # First letter (Community Porting|Supported Officially|OEM)
-DEVICE_STATUS="P"         # First letter (Planned|Test|Maintenance)
+DEVICE_SUPPORT_TYPE="C" # First letter (Community Porting|Supported Officially|OEM)
+DEVICE_STATUS="P"       # First letter (Planned|Test|Maintenance)
 
 # Import the Khadas vims configuration
 # shellcheck source=./recipes/devices/families/kvims.sh
 source "${SRC}"/recipes/devices/families/kvims.sh
 
-## WIP, this should be refactored out to a higher level.
 # Base system
 DEVICENAME="Khadas VIM2"
 DEVICE="kvim2"

--- a/recipes/devices/kvim3.sh
+++ b/recipes/devices/kvim3.sh
@@ -2,14 +2,13 @@
 # shellcheck disable=SC2034
 
 ## Setup for Khadas VIM3 board
-DEVICE_SUPPORT_TYPE="C"   # First letter (Community Porting|Supported Officially|OEM)
-DEVICE_STATUS="P"         # First letter (Planned|Test|Maintenance)
+DEVICE_SUPPORT_TYPE="C" # First letter (Community Porting|Supported Officially|OEM)
+DEVICE_STATUS="P"       # First letter (Planned|Test|Maintenance)
 
 # Import the Khadas vims configuration
 # shellcheck source=./recipes/devices/families/kvims.sh
 source "${SRC}"/recipes/devices/families/kvims.sh
 
-## WIP, this should be refactored out to a higher level.
 # Base system
 DEVICENAME="Khadas VIM3"
 DEVICE="kvim3"

--- a/recipes/devices/mp1.sh
+++ b/recipes/devices/mp1.sh
@@ -2,14 +2,13 @@
 # shellcheck disable=SC2034
 
 ## Setup for Khadas VIM3L boards (not to be published because it is OEM configured)
-DEVICE_SUPPORT_TYPE="O"   # First letter (Community Porting|Supported Officially|OEM)
-DEVICE_STATUS="T"         # First letter (Planned|Test|Maintenance)
+DEVICE_SUPPORT_TYPE="O" # First letter (Community Porting|Supported Officially|OEM)
+DEVICE_STATUS="T"       # First letter (Planned|Test|Maintenance)
 
 # Import the Khadas vims configuration
 # shellcheck source=./recipes/devices/families/kvims.sh
 source "${SRC}"/recipes/devices/families/kvims.sh
 
-## WIP, this should be refactored out to a higher level.
 # Base system
 DEVICENAME="Volumio MP1"
 DEVICE="mp1"
@@ -35,9 +34,8 @@ device_image_tweaks() {
   log "With VIM2/ VIM3/ MP1(VIM3L): adding fan services"
   cp "${PLTDIR}/${DEVICEBASE}/lib/systemd/system/fan.service" "${ROOTFSMNT}/lib/systemd/system"
 
-#TODO: remove the mp1 restriction when reboot works
-#do not use the system-halt.service for mp1 yet
+  #TODO: remove the mp1 restriction when reboot works
+  #do not use the system-halt.service for mp1 yet
   cp "${PLTDIR}/${DEVICEBASE}/etc/rc.local.mp1" "${ROOTFSMNT}/etc/rc.local"
 
 }
-

--- a/recipes/devices/nanopineo2.sh
+++ b/recipes/devices/nanopineo2.sh
@@ -2,13 +2,9 @@
 # shellcheck disable=SC2034
 
 ## Setup for NanoPi Neo2 H5 based devices
-DEVICE_SUPPORT_TYPE="C"   # First letter (Community Porting|Supported Officially|OEM)
-DEVICE_STATUS="P"         # First letter (Planned|Test|Maintenance)
+DEVICE_SUPPORT_TYPE="C" # First letter (Community Porting|Supported Officially|OEM)
+DEVICE_STATUS="P"       # First letter (Planned|Test|Maintenance)
 
-
-#TODO handle single base with multiple devices
-
-## WIP, this should be refactored out to a higher level.
 # Base system
 BASE="Debian"
 ARCH="arm64"

--- a/recipes/devices/nanopineo3.sh
+++ b/recipes/devices/nanopineo3.sh
@@ -2,10 +2,9 @@
 # shellcheck disable=SC2034
 
 ## Setup for FriendlyElec Nanopi Neo3  (Community Portings)
-DEVICE_SUPPORT_TYPE="C,O"   # First letter (Community Porting|Supported Officially|OEM)
+DEVICE_SUPPORT_TYPE="C,O" # First letter (Community Porting|Supported Officially|OEM)
 DEVICE_STATUS="P"         # First letter (Planned|Test|Maintenance)
 
-## WIP, this should be refactored out to a higher level.
 # Base system
 BASE="Debian"
 ARCH="armhf"

--- a/recipes/devices/odroidc1.sh
+++ b/recipes/devices/odroidc1.sh
@@ -2,12 +2,13 @@
 # shellcheck disable=SC2034
 
 ## Setup for Odroid C1 device  (Community Portings)
-DEVICE_SUPPORT_TYPE="C"   # First letter (Community Porting|Supported Officially|OEM)
-DEVICE_STATUS="P"         # First letter (Planned|Test|Maintenance)
+DEVICE_SUPPORT_TYPE="C" # First letter (Community Porting|Supported Officially|OEM)
+DEVICE_STATUS="P"       # First letter (Planned|Test|Maintenance)
 
 # shellcheck source=./recipes/devices/families/odroids-earlygen.sh
 source "${SRC}"/recipes/devices/families/odroids-earlygen.sh
 
+### Device information
 DEVICENAME="Odroid-C1"
 DEVICE="odroidc1"
 KERNELFILENAME="uImage"
@@ -15,4 +16,3 @@ DTBFILENAME="meson8b_odroidc.dtb"
 FRAMEBUFFERINIT="C1_init.sh"
 DDUBOOTPARMS="seek=64"
 UINITRD_ARCH="arm"
-

--- a/recipes/devices/odroidc2.sh
+++ b/recipes/devices/odroidc2.sh
@@ -2,12 +2,13 @@
 # shellcheck disable=SC2034
 
 ## Setup for Odroid C2 device
-DEVICE_SUPPORT_TYPE="C"   # First letter (Community Porting|Supported Officially|OEM)
-DEVICE_STATUS="P"         # First letter (Planned|Test|Maintenance)
+DEVICE_SUPPORT_TYPE="C" # First letter (Community Porting|Supported Officially|OEM)
+DEVICE_STATUS="P"       # First letter (Planned|Test|Maintenance)
 
 # shellcheck source=./recipes/devices/families/odroids-earlygen.sh
 source "${SRC}"/recipes/devices/families/odroids-earlygen.sh
 
+### Device information
 DEVICENAME="Odroid-C2"
 DEVICE="odroidc2"
 KERNELFILENAME="Image"
@@ -15,5 +16,3 @@ DTBFILENAME="meson64_odroidc2.dtb"
 FRAMEBUFFERINIT="C2_init.sh"
 DDUBOOTPARMS="conv=fsync bs=512 seek=97"
 UINITRD_ARCH="arm64"
-
-

--- a/recipes/devices/odroidc4.sh
+++ b/recipes/devices/odroidc4.sh
@@ -2,13 +2,12 @@
 # shellcheck disable=SC2034
 
 ## Setup for Odroid C4 device  (Community Portings)
-DEVICE_SUPPORT_TYPE="C"   # First letter (Community Porting|Supported Officially|OEM)
-DEVICE_STATUS="P"         # First letter (Planned|Test|Maintenance)
+DEVICE_SUPPORT_TYPE="C" # First letter (Community Porting|Supported Officially|OEM)
+DEVICE_STATUS="P"       # First letter (Planned|Test|Maintenance)
 
 # shellcheck source=./recipes/devices/families/odroids-newgen.sh
 source "${SRC}"/recipes/devices/families/odroids-newgen.sh
 
-# Base system
+### Device information
 DEVICENAME="Odroid-C4"
 DEVICE="odroidc4"
-

--- a/recipes/devices/odroidn2.sh
+++ b/recipes/devices/odroidn2.sh
@@ -2,13 +2,12 @@
 # shellcheck disable=SC2034
 
 ## Setup for Odroid N2/N2+ devices  (Community Portings)
-DEVICE_SUPPORT_TYPE="C"   # First letter (Community Porting|Supported Officially|OEM)
-DEVICE_STATUS="P"         # First letter (Planned|Test|Maintenance)
+DEVICE_SUPPORT_TYPE="C" # First letter (Community Porting|Supported Officially|OEM)
+DEVICE_STATUS="P"       # First letter (Planned|Test|Maintenance)
 
 # shellcheck source=./recipes/devices/families/odroids-newgen.sh
 source "${SRC}"/recipes/devices/families/odroids-newgen.sh
 
-# Base system
+### Device information
 DEVICENAME="Odroid-N2"
 DEVICE="odroidn2"
-

--- a/recipes/devices/odroidxu4.sh
+++ b/recipes/devices/odroidxu4.sh
@@ -2,10 +2,9 @@
 # shellcheck disable=SC2034
 
 ## Setup for Odroid XU4 device (Community Portings)
-DEVICE_SUPPORT_TYPE="C"   # First letter (Community Porting|Supported Officially|OEM)
-DEVICE_STATUS="P"         # First letter (Planned|Test|Maintenance)
+DEVICE_SUPPORT_TYPE="C" # First letter (Community Porting|Supported Officially|OEM)
+DEVICE_STATUS="P"       # First letter (Planned|Test|Maintenance)
 
-## WIP, this should be refactored out to a higher level.
 # Base system
 BASE="Debian"
 ARCH="armhf"
@@ -99,10 +98,10 @@ echo \$TRIP_POINT_2 > /sys/devices/virtual/thermal/thermal_zone2/trip_point_2_te
 echo \$TRIP_POINT_2 > /sys/devices/virtual/thermal/thermal_zone3/trip_point_2_temp
 exit 0
 EOF
-cat /etc/rc.local
+  cat /etc/rc.local
   log "Creating boot.ini from template"
   sed -i "s/%%VOLUMIO-PARAMS%%/imgpart=UUID=${UUID_IMG} bootpart=UUID=${UUID_BOOT} datapart=UUID=${UUID_DATA}/g" /boot/boot.ini
-cat /boot/boot.ini
+  cat /boot/boot.ini
   log "Tweaking: disable energy sensor error message"
   cat <<-EOF >>/etc/modprobe.d/blacklist-odroid.conf
 blacklist ina231_sensor

--- a/recipes/devices/orangepilite.sh
+++ b/recipes/devices/orangepilite.sh
@@ -2,13 +2,12 @@
 # shellcheck disable=SC2034
 
 ## Setup for Orange Pi H3 based devices
-DEVICE_SUPPORT_TYPE="C"   # First letter (Community Porting|Supported Officially|OEM)
-DEVICE_STATUS="P"         # First letter (Planned|Test|Maintenance)
+DEVICE_SUPPORT_TYPE="C" # First letter (Community Porting|Supported Officially|OEM)
+DEVICE_STATUS="P"       # First letter (Planned|Test|Maintenance)
 
 #TODO handle single base with multiple devices
 #orangepione|orangepilite|orangepipc
 
-## WIP, this should be refactored out to a higher level.
 # Base system
 BASE="Debian"
 ARCH="armhf"

--- a/recipes/devices/pi.sh
+++ b/recipes/devices/pi.sh
@@ -1,11 +1,9 @@
 #!/usr/bin/env bash
 # shellcheck disable=SC2034
 ## Setup for Raspberry Pi
-DEVICE_SUPPORT_TYPE="S"   # First letter (Community Porting|Supported Officially|OEM)
-DEVICE_STATUS="T"         # First letter (Planned|Test|Maintenance)
+DEVICE_SUPPORT_TYPE="S" # First letter (Community Porting|Supported Officially|OEM)
+DEVICE_STATUS="T"       # First letter (Planned|Test|Maintenance)
 
-## WIP: this should be refactored out to a higher level
-# Aka base config for arm,armv7,armv8 and x86
 # Base system
 BASE="Raspbian"
 ARCH="armhf"

--- a/recipes/devices/pine64base.sh
+++ b/recipes/devices/pine64base.sh
@@ -2,13 +2,13 @@
 # shellcheck disable=SC2034
 
 ## Setup for basic Pine64 devices  (Community Portings)
-DEVICE_SUPPORT_TYPE="C"   # First letter (Community Porting|Supported Officially|OEM)
-DEVICE_STATUS="P"         # First letter (Planned|Test|Maintenance)
+DEVICE_SUPPORT_TYPE="C" # First letter (Community Porting|Supported Officially|OEM)
+DEVICE_STATUS="P"       # First letter (Planned|Test|Maintenance)
 
 # shellcheck source=./recipes/devices/families/pine64.sh
 source "${SRC}"/recipes/devices/families/pine64.sh
 
+### Device information
 DEVICENAME="Pine64"
 DEVICE="pine64"
 UBOOT_VARIANT="pine64plus"
-

--- a/recipes/devices/pine64plus.sh
+++ b/recipes/devices/pine64plus.sh
@@ -2,13 +2,13 @@
 # shellcheck disable=SC2034
 
 ## Setup for Pine64+ devices  (Community Portings)
-DEVICE_SUPPORT_TYPE="C"   # First letter (Community Porting|Supported Officially|OEM)
-DEVICE_STATUS="P"         # First letter (Planned|Test|Maintenance)
+DEVICE_SUPPORT_TYPE="C" # First letter (Community Porting|Supported Officially|OEM)
+DEVICE_STATUS="P"       # First letter (Planned|Test|Maintenance)
 
 # shellcheck source=./recipes/devices/families/pine64.sh
 source "${SRC}"/recipes/devices/families/pine64.sh
 
+### Device information
 DEVICENAME="Pine64+"
 DEVICE="pine64plus"
 UBOOT_VARIANT="pine64plus"
-

--- a/recipes/devices/pine64solts.sh
+++ b/recipes/devices/pine64solts.sh
@@ -2,13 +2,13 @@
 # shellcheck disable=SC2034
 
 ## Setup for soPine64 and Pine64LTS devices  (Community Portings)
-DEVICE_SUPPORT_TYPE="C"   # First letter (Community Porting|Supported Officially|OEM)
-DEVICE_STATUS="P"         # First letter (Planned|Test|Maintenance)
+DEVICE_SUPPORT_TYPE="C" # First letter (Community Porting|Supported Officially|OEM)
+DEVICE_STATUS="P"       # First letter (Planned|Test|Maintenance)
 
 # shellcheck source=./recipes/devices/families/pine64.sh
 source "${SRC}"/recipes/devices/families/pine64.sh
 
+### Device information
 DEVICENAME="soPine64-Pine64LTS"
 DEVICE="pine64solts"
 UBOOT_VARIANT="pine64solts"
-

--- a/recipes/devices/rock64.sh
+++ b/recipes/devices/rock64.sh
@@ -2,10 +2,9 @@
 # shellcheck disable=SC2034
 
 ## Setup for Rock64 (pine64.org) devices (Community Portings)
-DEVICE_SUPPORT_TYPE="C"   # First letter (Community Porting|Supported Officially|OEM)
-DEVICE_STATUS="P"         # First letter (Planned|Test|Maintenance)
+DEVICE_SUPPORT_TYPE="C" # First letter (Community Porting|Supported Officially|OEM)
+DEVICE_STATUS="P"       # First letter (Planned|Test|Maintenance)
 
-## WIP, this should be refactored out to a higher level.
 # Base system
 BASE="Debian"
 ARCH="armhf"

--- a/recipes/devices/rockpis.sh
+++ b/recipes/devices/rockpis.sh
@@ -1,10 +1,9 @@
 #!/usr/bin/env bash
 # shellcheck disable=SC2034
 ## Setup for Radxa Rock Pi S
-DEVICE_SUPPORT_TYPE="C"   # First letter (Community Porting|Supported Officially|OEM)
-DEVICE_STATUS="P"         # First letter (Planned|Test|Maintenance)
+DEVICE_SUPPORT_TYPE="C" # First letter (Community Porting|Supported Officially|OEM)
+DEVICE_STATUS="P"       # First letter (Planned|Test|Maintenance)
 
-## WIP, this should be refactored out to a higher level.
 # Base system
 BASE="Debian"
 #ARCH="arm64"

--- a/recipes/devices/tinkerboard.sh
+++ b/recipes/devices/tinkerboard.sh
@@ -2,12 +2,9 @@
 # shellcheck disable=SC2034
 
 ## Setup for Asus Tinerboard device
-DEVICE_SUPPORT_TYPE="S"   # First letter (Community Porting|Supported Officially|OEM)
-DEVICE_STATUS="T"         # First letter (Planned|Test|Maintenance)
+DEVICE_SUPPORT_TYPE="S" # First letter (Community Porting|Supported Officially|OEM)
+DEVICE_STATUS="T"       # First letter (Planned|Test|Maintenance)
 
-#TODO handle single base with multiple devices
-
-## WIP, this should be refactored out to a higher level.
 # Base system
 BASE="Debian"
 ARCH="armhf"

--- a/recipes/devices/x86_amd64.sh
+++ b/recipes/devices/x86_amd64.sh
@@ -2,14 +2,14 @@
 # shellcheck disable=SC2034
 
 ### Setup for x86_amd64 devices
-DEVICE_SUPPORT_TYPE="S"   # First letter (Community Porting|Supported Officially|OEM)
-DEVICE_STATUS="T"         # First letter (Planned|Test|Maintenance)
+DEVICE_SUPPORT_TYPE="S" # First letter (Community Porting|Supported Officially|OEM)
+DEVICE_STATUS="T"       # First letter (Planned|Test|Maintenance)
 
 # Import the x86 base family configuration
 # shellcheck source=./recipes/devices/families/x86.sh
 source "${SRC}"/recipes/devices/families/x86.sh
 
-# And only adjust the bits that are different
+# Base system
 ARCH="amd64"
 BUILD="x64"
 DEVICENAME="x86_64"

--- a/recipes/devices/x86_i386.sh
+++ b/recipes/devices/x86_i386.sh
@@ -2,14 +2,14 @@
 # shellcheck disable=SC2034
 
 ### Setup for x86_i386 devices
-DEVICE_SUPPORT_TYPE="S"   # First letter (Community Porting|Supported Officially|OEM)
-DEVICE_STATUS="T"         # First letter (Planned|Test|Maintenance)
+DEVICE_SUPPORT_TYPE="S" # First letter (Community Porting|Supported Officially|OEM)
+DEVICE_STATUS="T"       # First letter (Planned|Test|Maintenance)
 
 # Import the x86 base family configuration
 # shellcheck source=./recipes/devices/families/x86.sh
 source "${SRC}"/recipes/devices/families/x86.sh
 
-# And only adjust the bits that are different
+# Base system
 ARCH="i386"
 BUILD="x86"
 DEVICENAME="x86"


### PR DESCRIPTION
Added some placeholders, should be updated to reflect [`Device table`](https://github.com/volumio/Build/blob/volumioOS/recipes/devices/README.MD#devices) from 2401d04 

Btw, while looking at our device support table, I released current build system don't support multi device build ergonomically yet e.g `Kvims` `Orangepi{one|lite|pc}` -- something that needs to be worked on..