### PR TITLE
Create userconfig.txt on firstart only on Raspberry devices

### DIFF
--- a/volumio/bin/firststart.sh
+++ b/volumio/bin/firststart.sh
@@ -1,15 +1,21 @@
-#!/bin/bash
+#!/usr/bin/env bash
+set -eo pipefail
+
+#shellcheck source=/dev/null
+source /etc/os-release
 
 echo "Volumio first start configuration script"
 
-echo "configuring unconfigured packages"
+echo "Configuring unconfigured packages"
 dpkg --configure --pending
 
 echo "Creating /var/log/samba/cores folder"
 mkdir -p /var/log/samba/cores && chmod -R 0700 "$_"
 
-echo "Creating /boot/userconfig.txt"
-echo "# Add your custom config.txt options to this file, which will be preserved during updates" >> /boot/userconfig.txt
+if [[ ${VOLUMIO_HARDWARE} == "pi" ]]; then
+  echo "Creating /boot/userconfig.txt"
+  echo "# Add your custom config.txt options to this file, which will be preserved during updates" >>/boot/userconfig.txt
+fi
 
 echo "Removing default SSH host keys"
 # These should be created on first boot to ensure they are unique on each system


### PR DESCRIPTION
Few questions though, 

-- Does this script run on every upgrade? Or only on the first time the image is flashed and run? 
-- Why are we appending, shouldn't it rather check if the file exists and if not create it? 
