### PR TITLE
[x86] Tweak kernel version selection

### DIFF
--- a/recipes/devices/families/x86.sh
+++ b/recipes/devices/families/x86.sh
@@ -165,11 +165,10 @@ device_chroot_tweaks_pre() {
   # Since our boot partition is FAT, it doesn't support sylminks.
   #shellcheck disable=SC2012 # We know it's going to be alphanumeric only!
   mapfile -t KRNL_VERS < <(ls -t /boot/vmlinuz* | sort)
-  log "Found ${#KRNL_VERS[@]} kernel(s)" "${KRNL_VERS[@]}"
-  KRNL=$(echo ${KRNL_VERS[0]##*/} | awk -F "-" '{print $1}')
-  log "Finished Kernel ${KRNL_VERS[0]} installation" "okay" "${KRNL}"
-  mv ${KRNL_VERS[@]} /boot/${KRNL}
-
+  log "Found ${#KRNL_VERS[@]} kernel(s)" "${KRNL_VERS[*]}"
+  KRNL="vmlinuz" # As we can't symlink, we rename our current kerenl to `vmlinuz`
+  mv "${KRNL_VERS[0]}" /boot/${KRNL}
+  log "Finished Kernel ${KRNL_VERS[0]} installation to:" "okay" "/boot/${KRNL}"
   ls -l /boot
 
   log "Preparing BIOS" "info"


### PR DESCRIPTION
From a2efe8bf5e7da00eb639ec8105168f09d01ebd16, isn't 
https://github.com/volumio/Build/blob/a2efe8bf5e7da00eb639ec8105168f09d01ebd16/recipes/devices/families/x86.sh#L169-L170
a rather roundabout way of just setting the current kernel to `vmlinuz`? i.e `KRNL=vmlinuz`

The initial stuff was written to handle multiple kernels - on my system,
```
lrwxrwxrwx 1 root root       24 jul 29  2020 /boot/vmlinuz -> vmlinuz-5.3.0-64-generic
-rw------- 1 root root 11412224 jun  3  2020 /boot/vmlinuz-5.3.0-59-generic
-rw------- 1 root root 11416320 jun 23  2020 /boot/vmlinuz-5.3.0-62-generic
-rw------- 1 root root 11416320 jul 10  2020 /boot/vmlinuz-5.3.0-64-generic
lrwxrwxrwx 1 root root       24 jul 29  2020 /boot/vmlinuz.old -> vmlinuz-5.3.0-62-generic
```
This gives:
```
mapfile -t KRNL_VERS < <(ls -t /boot/vmlinuz-* | sort)
log "Found ${#KRNL_VERS[@]} kernel(s)" "${KRNL_VERS[*]}"
KRNL=${KRNL_VERS[0]##*/}
IFS=- read -ra KVER <<<"$KRNL"
log "KRNL: ${KRNL}"
log "KVER[${#KVER[@]}]:  ${KVER[*]}"

[ .. ] Found 3 kernel(s) [ /boot/vmlinuz-5.3.0-59-generic /boot/vmlinuz-5.3.0-62-generic /boot/vmlinuz-5.3.0-64-generic ]
[ .. ] KRNL: vmlinuz-5.3.0-59-generic 
[ .. ] KVER[4]:  vmlinuz 5.3.0 59 generic 
[ o.k. ] Finished Kernel 5.3.0 installation  [ vmlinuz-5.3.0-59-generic ]
```
-- so `KRNL_VERS` was an array of the different kernels found, and `KRNL` would then pick the most recent version.
`KVER` is then an array built by splitting `$KRNL` on `-` 


But the current code is a bit of a mix b/w handling multiple kernels, and single ones and thus
```
mv ${KRNL_VERS[@]} /boot/${KRNL}
# would expand to 
mv /boot/vmlinuz-5.3.0-59-generic /boot/vmlinuz-5.3.0-62-generic /boot/vmlinuz-5.3.0-64-generic /boot/vmlinuz
```

However, all this is probably moot as I believe we would only have a single Kernel in /boot (especially during image building time) so I simplified it to explicitly set it directly to `vmlinuz` to avoid any confusion.

