### PR TITLE
Cleanup more redudndant `mpd.conf`

### DIFF
--- a/scripts/volumio/configure.sh
+++ b/scripts/volumio/configure.sh
@@ -61,10 +61,6 @@ cp "${SRC}/volumio/etc/inittab" "${ROOTFS}/etc/inittab"
 #SSH
 cp "${SRC}/volumio/etc/ssh/sshd_config" "${ROOTFS}/etc/ssh/sshd_config"
 
-#Mpd
-cp "${SRC}/volumio/etc/mpd.conf" "${ROOTFS}/etc/mpd.conf"
-chmod 777 "${ROOTFS}/etc/mpd.conf"
-
 #Log via JournalD in RAM
 cp "${SRC}/volumio/etc/systemd/journald.conf" "${ROOTFS}/etc/systemd/journald.conf"
 


### PR DESCRIPTION
Didn't push everything in #470.
Strangely the `mpd.conf` file was being copied twice for some reason, once in `build.sh` that was removed in 20e3c8c
and then again in `configure.sh` that this cleans up..