### PR TITLE
Workaround for configuration files for  custom packages not installed…

### DIFF
--- a/scripts/volumio/finalize.sh
+++ b/scripts/volumio/finalize.sh
@@ -81,6 +81,10 @@ log "Updating MOTD"
 rm -f ${ROOTFSMNT}/etc/motd ${ROOTFSMNT}/etc/update-motd.d/*
 cp "${SRC}"/volumio/etc/update-motd.d/* ${ROOTFSMNT}/etc/update-motd.d/
 
+# Temporary workaround
+log "Copying over upmpdcli.service"
+cp "${SRC}"/volumio/lib/systemd/system/upmpdcli.service ${ROOTFSMNT}/lib/systemd/system/upmpdcli.service
+
 log "Add Volumio WebUI IP"
 cat <<-EOF >>${ROOTFSMNT}/etc/issue
 Welcome to Volumio!


### PR DESCRIPTION
… during rootfs creation

Fixes https://github.com/volumio/Build/issues/479

PS: Can't test ATM but should work in theory. 