### PR TITLE
Streamline `uInitrd` creation

### DIFF
--- a/recipes/devices/cuboxp.sh
+++ b/recipes/devices/cuboxp.sh
@@ -98,6 +98,6 @@ device_image_tweaks_post() {
   fi
   if [[ -f "${ROOTFSMNT}"/boot/boot.cmd ]]; then
     log "Creating boot.scr"
-    mkimage -A "${UINITRD_ARCH}" -T script -C none -d "${ROOTFSMNT}"/boot/boot.cmd "${ROOTFSMNT}"/boot/boot.scr
+    mkimage -A arm -T script -C none -d "${ROOTFSMNT}"/boot/boot.cmd "${ROOTFSMNT}"/boot/boot.scr
   fi
 }

--- a/recipes/devices/cuboxp.sh
+++ b/recipes/devices/cuboxp.sh
@@ -11,6 +11,7 @@ DEVICE_STATUS="P"       # First letter (Planned|Test|Maintenance)
 BASE="Debian"
 ARCH="armhf"
 BUILD="armv7"
+UINITRD_ARCH="arm64"
 
 ### Device information
 DEVICENAME="Cubox Pulse"
@@ -83,21 +84,20 @@ EOF
 
 # Will be run in chroot - Post initramfs
 device_chroot_tweaks_post() {
-  log "Running device_chroot_tweaks_post" "ext"
-
-  log "Creating uInitrd from 'volumio.initrd'" "info"
-  #TODO This can be done outside chroot,
-  # removing the need of each image needing u-boot-tools
-  # saving some time!
-  mkimage -v -A arm64 -O linux -T ramdisk -C none -a 0 -e 0 -n uInitrd -d /boot/volumio.initrd /boot/uInitrd
-  log "Removing unnecessary /boot files"
-  rm /boot/volumio.initrd
-  log "Compiling u-boot boot script"
-  mkimage -C none -A arm -T script -d /boot/boot.cmd /boot/boot.scr
+  # log "Running device_chroot_tweaks_post" "ext"
+  :
 }
 
 # Will be called by the image builder post the chroot, before finalisation
 device_image_tweaks_post() {
-  # log "Running device_chroot_tweaks_post" "ext"
-  :
+  log "Running device_image_tweaks_post" "ext"
+  log "Creating uInitrd from 'volumio.initrd'" "info"
+  if [[ -f "${ROOTFSMNT}"/boot/volumio.initrd ]]; then
+    mkimage -v -A "${UINITRD_ARCH}" -O linux -T ramdisk -C none -a 0 -e 0 -n uInitrd -d "${ROOTFSMNT}"/boot/volumio.initrd "${ROOTFSMNT}"/boot/uInitrd
+    rm "${ROOTFSMNT}"/boot/volumio.initrd
+  fi
+  if [[ -f "${ROOTFSMNT}"/boot/boot.cmd ]]; then
+    log "Creating boot.scr"
+    mkimage -A "${UINITRD_ARCH}" -T script -C none -d "${ROOTFSMNT}"/boot/boot.cmd "${ROOTFSMNT}"/boot/boot.scr
+  fi
 }

--- a/recipes/devices/cuboxp.sh
+++ b/recipes/devices/cuboxp.sh
@@ -38,7 +38,7 @@ INIT_TYPE="init.nextarm" # init.{x86/nextarm/nextarm_tvbox}
 # Modules that will be added to intramsfs
 MODULES=("overlay" "squashfs" "nls_cp437")
 # Packages that will be installed
-PACKAGES=("u-boot-tools" "device-tree-compiler")
+# PACKAGES=("u-boot-tools" "device-tree-compiler")
 
 ### Device customisation
 # Copy the device specific files (Image/DTS/etc..)

--- a/recipes/devices/cuboxp.sh
+++ b/recipes/devices/cuboxp.sh
@@ -95,3 +95,9 @@ device_chroot_tweaks_post() {
   log "Compiling u-boot boot script"
   mkimage -C none -A arm -T script -d /boot/boot.cmd /boot/boot.scr
 }
+
+# Will be called by the image builder post the chroot, before finalisation
+device_image_tweaks_post() {
+  # log "Running device_chroot_tweaks_post" "ext"
+  :
+}

--- a/recipes/devices/families/kvims.sh
+++ b/recipes/devices/families/kvims.sh
@@ -7,6 +7,7 @@
 BASE="Debian"
 ARCH="armhf"
 BUILD="armv7"
+UINITRD_ARCH="arm"
 
 ### Device information
 # This is useful for multiple devices sharing the same/similar kernel
@@ -136,18 +137,14 @@ device_chroot_tweaks_post() {
     ln -s "/lib/systemd/system/fan.service" "/etc/systemd/system/multi-user.target.wants/fan.service"
   fi
 
-  #TODO This can be done outside chroot,
-  # removing the need of each image needing u-boot-tools
-  # saving some time!
-  if [[ -f /boot/volumio.initrd ]]; then
-    log "Creating uInitrd from 'volumio.initrd'" "info"
-    mkimage -v -A arm -O linux -T ramdisk -C none -a 0 -e 0 -n uInitrd -d /boot/volumio.initrd /boot/uInitrd
-    rm /boot/volumio.initrd
-  fi
 }
 
 # Will be called by the image builder post the chroot, before finalisation
 device_image_tweaks_post() {
-  # log "Running device_chroot_tweaks_post" "ext"
-  :
+  log "Running device_image_tweaks_post" "ext"
+  log "Creating uInitrd from 'volumio.initrd'" "info"
+  if [[ -f "${ROOTFSMNT}"/boot/volumio.initrd ]]; then
+    mkimage -v -A "${UINITRD_ARCH}" -O linux -T ramdisk -C none -a 0 -e 0 -n uInitrd -d "${ROOTFSMNT}"/boot/volumio.initrd "${ROOTFSMNT}"/boot/uInitrd
+    rm "${ROOTFSMNT}"/boot/volumio.initrd
+  fi
 }

--- a/recipes/devices/families/kvims.sh
+++ b/recipes/devices/families/kvims.sh
@@ -145,3 +145,9 @@ device_chroot_tweaks_post() {
     rm /boot/volumio.initrd
   fi
 }
+
+# Will be called by the image builder post the chroot, before finalisation
+device_image_tweaks_post() {
+  # log "Running device_chroot_tweaks_post" "ext"
+  :
+}

--- a/recipes/devices/families/kvims.sh
+++ b/recipes/devices/families/kvims.sh
@@ -34,7 +34,7 @@ INIT_TYPE="init.nextarm" # init.{x86/nextarm/nextarm_tvbox}
 # Modules that will be added to intramsfs
 MODULES=("overlay" "squashfs" "nls_cp437")
 # Packages that will be installed
-PACKAGES=("u-boot-tools" "lirc" "fbset" "mc" "abootimg" "bluez-firmware"
+PACKAGES=("lirc" "fbset" "mc" "abootimg" "bluez-firmware"
   "bluetooth" "bluez" "bluez-tools" "linux-base" "triggerhappy"
 )
 

--- a/recipes/devices/families/odroids-earlygen.sh
+++ b/recipes/devices/families/odroids-earlygen.sh
@@ -118,18 +118,14 @@ device_chroot_tweaks_post() {
   cp lircrc /etc/lirc
   rm lircd.conf hardware.conf lircrc
 
-  #TODO This can be done outside chroot,
-  # removing the need of each image needing u-boot-tools
-  # saving some time!
-  if [[ -f /boot/volumio.initrd ]]; then
-    log "Creating uInitrd from 'volumio.initrd'" "info"
-    mkimage -v -A ${UINITRD_ARCH} -O linux -T ramdisk -C none -a 0 -e 0 -n uInitrd -d /boot/volumio.initrd /boot/uInitrd
-    rm /boot/volumio.initrd
-  fi
 }
 
 # Will be called by the image builder post the chroot, before finalisation
 device_image_tweaks_post() {
-  # log "Running device_chroot_tweaks_post" "ext"
-  :
+  log "Running device_image_tweaks_post" "ext"
+  log "Creating uInitrd from 'volumio.initrd'" "info"
+  if [[ -f "${ROOTFSMNT}"/boot/volumio.initrd ]]; then
+    mkimage -v -A "${UINITRD_ARCH}" -O linux -T ramdisk -C none -a 0 -e 0 -n uInitrd -d "${ROOTFSMNT}"/boot/volumio.initrd "${ROOTFSMNT}"/boot/uInitrd
+    rm "${ROOTFSMNT}"/boot/volumio.initrd
+  fi
 }

--- a/recipes/devices/families/odroids-earlygen.sh
+++ b/recipes/devices/families/odroids-earlygen.sh
@@ -31,7 +31,7 @@ FLAGS_EXT4=("-O" "^metadata_csum,^64bit") # Disable ext4 metadata checksums
 # Modules that will be added to intramsfs
 MODULES=("overlayfs" "overlay" "squashfs" "nls_cp437")
 # Packages that will be installed
-PACKAGES=("u-boot-tools" "liblircclient0" "lirc" "fbset")
+PACKAGES=("liblircclient0" "lirc" "fbset")
 
 ### Device customisation
 # Copy the device specific files (Image/DTS/etc..)

--- a/recipes/devices/families/odroids-earlygen.sh
+++ b/recipes/devices/families/odroids-earlygen.sh
@@ -127,3 +127,9 @@ device_chroot_tweaks_post() {
     rm /boot/volumio.initrd
   fi
 }
+
+# Will be called by the image builder post the chroot, before finalisation
+device_image_tweaks_post() {
+  # log "Running device_chroot_tweaks_post" "ext"
+  :
+}

--- a/recipes/devices/families/odroids-newgen.sh
+++ b/recipes/devices/families/odroids-newgen.sh
@@ -31,7 +31,7 @@ INIT_TYPE="init.nextarm" # init.{x86/nextarm/nextarm_tvbox}
 # Modules that will be added to intramsfs
 MODULES=("overlay" "squashfs" "nls_cp437")
 # Packages that will be installed
-PACKAGES=("u-boot-tools" "lirc" "fbset")
+PACKAGES=("lirc" "fbset")
 
 ### Device customisation
 # Copy the device specific files (Image/DTS/etc..)

--- a/recipes/devices/families/odroids-newgen.sh
+++ b/recipes/devices/families/odroids-newgen.sh
@@ -97,3 +97,9 @@ device_chroot_tweaks_post() {
     rm /boot/volumio.initrd
   fi
 }
+
+# Will be called by the image builder post the chroot, before finalisation
+device_image_tweaks_post() {
+  # log "Running device_chroot_tweaks_post" "ext"
+  :
+}

--- a/recipes/devices/families/odroids-newgen.sh
+++ b/recipes/devices/families/odroids-newgen.sh
@@ -7,7 +7,7 @@
 BASE="Debian"
 ARCH="armhf"
 BUILD="armv7"
-UINITRD_ARCH="arm" # TODO: Confirm with Gé, think it should be arm64
+UINITRD_ARCH="arm64"
 
 ### Device information
 DEVICEFAMILY="odroid"

--- a/recipes/devices/families/odroids-newgen.sh
+++ b/recipes/devices/families/odroids-newgen.sh
@@ -7,6 +7,7 @@
 BASE="Debian"
 ARCH="armhf"
 BUILD="armv7"
+UINITRD_ARCH="arm" # TODO: Confirm with Gé, think it should be arm64
 
 ### Device information
 DEVICEFAMILY="odroid"
@@ -88,18 +89,14 @@ device_chroot_tweaks_post() {
   cp lircrc /etc/lirc
   rm lircd.conf hardware.conf lircrc
 
-  #TODO This can be done outside chroot,
-  # removing the need of each image needing u-boot-tools
-  # saving some time!
-  if [[ -f /boot/volumio.initrd ]]; then
-    log "Creating uInitrd from 'volumio.initrd'" "info"
-    mkimage -v -A arm -O linux -T ramdisk -C none -a 0 -e 0 -n uInitrd -d /boot/volumio.initrd /boot/uInitrd
-    rm /boot/volumio.initrd
-  fi
 }
 
 # Will be called by the image builder post the chroot, before finalisation
 device_image_tweaks_post() {
-  # log "Running device_chroot_tweaks_post" "ext"
-  :
+  log "Running device_image_tweaks_post" "ext"
+  log "Creating uInitrd from 'volumio.initrd'" "info"
+  if [[ -f "${ROOTFSMNT}"/boot/volumio.initrd ]]; then
+    mkimage -v -A "${UINITRD_ARCH}" -O linux -T ramdisk -C none -a 0 -e 0 -n uInitrd -d "${ROOTFSMNT}"/boot/volumio.initrd "${ROOTFSMNT}"/boot/uInitrd
+    rm "${ROOTFSMNT}"/boot/volumio.initrd
+  fi
 }

--- a/recipes/devices/families/pine64.sh
+++ b/recipes/devices/families/pine64.sh
@@ -7,6 +7,7 @@
 BASE="Debian"
 ARCH="armhf"
 BUILD="armv7"
+UINITRD_ARCH="arm"
 
 ### Device information
 DEVICEBASE="pine64-all"
@@ -99,24 +100,20 @@ EOF
 
 # Will be run in chroot - Post initramfs
 device_chroot_tweaks_post() {
-  log "Running device_chroot_tweaks_post" "ext"
-
-  #TODO This can be done outside chroot,
-  # removing the need of each image needing u-boot-tools
-  # saving some time!
-
-  log "Creating boot script from boot.cmd"
-  mkimage -C none -A arm -T script -d /boot/boot.cmd /boot/boot.scr
-
-  if [[ -f /boot/volumio.initrd ]]; then
-    log "Creating uInitrd from 'volumio.initrd'" "info"
-    mkimage -v -A arm -O linux -T ramdisk -C none -a 0 -e 0 -n uInitrd -d /boot/volumio.initrd /boot/uInitrd
-    rm /boot/volumio.initrd
-  fi
+  # log "Running device_chroot_tweaks_post" "ext"
+  :
 }
 
 # Will be called by the image builder post the chroot, before finalisation
 device_image_tweaks_post() {
-  # log "Running device_chroot_tweaks_post" "ext"
-  :
+  log "Running device_image_tweaks_post" "ext"
+  log "Creating uInitrd from 'volumio.initrd'" "info"
+  if [[ -f "${ROOTFSMNT}"/boot/volumio.initrd ]]; then
+    mkimage -v -A "${UINITRD_ARCH}" -O linux -T ramdisk -C none -a 0 -e 0 -n uInitrd -d "${ROOTFSMNT}"/boot/volumio.initrd "${ROOTFSMNT}"/boot/uInitrd
+    rm "${ROOTFSMNT}"/boot/volumio.initrd
+  fi
+  if [[ -f "${ROOTFSMNT}"/boot/boot.cmd ]]; then
+    log "Creating boot.scr"
+    mkimage -A "${UINITRD_ARCH}" -T script -C none -d "${ROOTFSMNT}"/boot/boot.cmd "${ROOTFSMNT}"/boot/boot.scr
+  fi
 }

--- a/recipes/devices/families/pine64.sh
+++ b/recipes/devices/families/pine64.sh
@@ -114,3 +114,9 @@ device_chroot_tweaks_post() {
     rm /boot/volumio.initrd
   fi
 }
+
+# Will be called by the image builder post the chroot, before finalisation
+device_image_tweaks_post() {
+  # log "Running device_chroot_tweaks_post" "ext"
+  :
+}

--- a/recipes/devices/families/pine64.sh
+++ b/recipes/devices/families/pine64.sh
@@ -32,7 +32,7 @@ INIT_TYPE="init.nextarm" # init.{x86/nextarm/nextarm_tvbox}
 # Modules that will be added to intramsfs
 MODULES=("overlay" "squashfs" "nls_cp437")
 # Packages that will be installed
-PACKAGES=("u-boot-tools" "liblircclient0" "lirc" "libcdio-dev" "libcdparanoia-dev" "bluez-firmware" "bluetooth" "bluez" "bluez-tools")
+PACKAGES=("liblircclient0" "lirc" "libcdio-dev" "libcdparanoia-dev" "bluez-firmware" "bluetooth" "bluez" "bluez-tools")
 
 ### Device customisation
 # Copy the device specific files (Image/DTS/etc..)

--- a/recipes/devices/families/pine64.sh
+++ b/recipes/devices/families/pine64.sh
@@ -114,6 +114,6 @@ device_image_tweaks_post() {
   fi
   if [[ -f "${ROOTFSMNT}"/boot/boot.cmd ]]; then
     log "Creating boot.scr"
-    mkimage -A "${UINITRD_ARCH}" -T script -C none -d "${ROOTFSMNT}"/boot/boot.cmd "${ROOTFSMNT}"/boot/boot.scr
+    mkimage -A arm -T script -C none -d "${ROOTFSMNT}"/boot/boot.cmd "${ROOTFSMNT}"/boot/boot.scr
   fi
 }

--- a/recipes/devices/families/pine64.sh
+++ b/recipes/devices/families/pine64.sh
@@ -7,7 +7,7 @@
 BASE="Debian"
 ARCH="armhf"
 BUILD="armv7"
-UINITRD_ARCH="arm"
+UINITRD_ARCH="arm64"
 
 ### Device information
 DEVICEBASE="pine64-all"

--- a/recipes/devices/families/x86.sh
+++ b/recipes/devices/families/x86.sh
@@ -271,6 +271,6 @@ device_chroot_tweaks_post() {
 
 # Will be called by the image builder post the chroot, before finalisation
 device_image_tweaks_post() {
-  # log "Running device_chroot_tweaks_post" "ext"
+  # log "Running device_image_tweaks_post" "ext"
   :
 }

--- a/recipes/devices/families/x86.sh
+++ b/recipes/devices/families/x86.sh
@@ -247,7 +247,6 @@ EOF
   sed -i "s/%%BOOTPART%%/${UUID_BOOT}/g" ${grub_cfg}
   sed -i "s/%%DATAPART%%/${UUID_DATA}/g" ${grub_cfg}
 
-
   log "Finished setting up boot config" "okay"
 
   log "Creating fstab template to be used in initrd"
@@ -268,4 +267,10 @@ device_chroot_tweaks_post() {
   log "Cleaning up /boot"
   log "Removing System.map" "$(ls -lh --block-size=M /boot/System.map-*)"
   rm /boot/System.map-*
+}
+
+# Will be called by the image builder post the chroot, before finalisation
+device_image_tweaks_post() {
+  # log "Running device_chroot_tweaks_post" "ext"
+  :
 }

--- a/recipes/devices/nanopineo2.sh
+++ b/recipes/devices/nanopineo2.sh
@@ -92,3 +92,9 @@ device_chroot_tweaks_post() {
     mkimage -A $ARCH -T script -C none -d /boot/boot.cmd /boot/boot.scr
   fi
 }
+
+# Will be called by the image builder post the chroot, before finalisation
+device_image_tweaks_post() {
+  # log "Running device_chroot_tweaks_post" "ext"
+  :
+}

--- a/recipes/devices/nanopineo2.sh
+++ b/recipes/devices/nanopineo2.sh
@@ -9,6 +9,7 @@ DEVICE_STATUS="P"       # First letter (Planned|Test|Maintenance)
 BASE="Debian"
 ARCH="arm64"
 BUILD="armv8"
+UINITRD_ARCH="arm64"
 
 ### Device information
 DEVICENAME="NanoPi Neo2"
@@ -33,7 +34,7 @@ INIT_TYPE="init.nextarm" # init.{x86/nextarm/nextarm_tvbox}
 # Modules that will be added to intramsfs
 MODULES=("overlay" "overlayfs" "squashfs" "nls_cp437" "fuse")
 # Packages that will be installed
-PACKAGES=("u-boot-tools")
+# PACKAGES=("u-boot-tools")
 
 ### Device customisation
 # Copy the device specific files (Image/DTS/etc..)
@@ -78,23 +79,19 @@ device_chroot_tweaks_pre() {
 
 # Will be run in chroot - Post initramfs
 device_chroot_tweaks_post() {
-  log "Running device_chroot_tweaks_post" "ext"
-
-  #TODO This can be done outside chroot,
-  # removing the need of each image needing u-boot-tools
-  # saving some time!
-  log "Creating uInitrd from 'volumio.initrd'" "info"
-  if [[ -f /boot/volumio.initrd ]]; then
-    mkimage -v -A $ARCH -O linux -T ramdisk -C none -a 0 -e 0 -n uInitrd -d /boot/volumio.initrd /boot/uInitrd
-  fi
-  if [[ -f /boot/boot.cmd ]]; then
-    log "Creating boot.scr"
-    mkimage -A $ARCH -T script -C none -d /boot/boot.cmd /boot/boot.scr
-  fi
+  :
 }
 
 # Will be called by the image builder post the chroot, before finalisation
 device_image_tweaks_post() {
-  # log "Running device_chroot_tweaks_post" "ext"
-  :
+  log "Running device_image_tweaks_post" "ext"
+  log "Creating uInitrd from 'volumio.initrd'" "info"
+  if [[ -f "${ROOTFSMNT}"/boot/volumio.initrd ]]; then
+    mkimage -v -A "${UINITRD_ARCH}" -O linux -T ramdisk -C none -a 0 -e 0 -n uInitrd -d "${ROOTFSMNT}"/boot/volumio.initrd "${ROOTFSMNT}"/boot/uInitrd
+    rm "${ROOTFSMNT}"/boot/volumio.initrd
+  fi
+  if [[ -f "${ROOTFSMNT}"/boot/boot.cmd ]]; then
+    log "Creating boot.scr"
+    mkimage -A "${UINITRD_ARCH}" -T script -C none -d "${ROOTFSMNT}"/boot/boot.cmd "${ROOTFSMNT}"/boot/boot.scr
+  fi
 }

--- a/recipes/devices/nanopineo2.sh
+++ b/recipes/devices/nanopineo2.sh
@@ -92,6 +92,6 @@ device_image_tweaks_post() {
   fi
   if [[ -f "${ROOTFSMNT}"/boot/boot.cmd ]]; then
     log "Creating boot.scr"
-    mkimage -A "${UINITRD_ARCH}" -T script -C none -d "${ROOTFSMNT}"/boot/boot.cmd "${ROOTFSMNT}"/boot/boot.scr
+    mkimage -A arm -T script -C none -d "${ROOTFSMNT}"/boot/boot.cmd "${ROOTFSMNT}"/boot/boot.scr
   fi
 }

--- a/recipes/devices/nanopineo3.sh
+++ b/recipes/devices/nanopineo3.sh
@@ -102,3 +102,9 @@ device_chroot_tweaks_post() {
   log "Removing unnecessary /boot files"
   rm /boot/volumio.initrd
 }
+
+# Will be called by the image builder post the chroot, before finalisation
+device_image_tweaks_post() {
+  # log "Running device_chroot_tweaks_post" "ext"
+  :
+}

--- a/recipes/devices/nanopineo3.sh
+++ b/recipes/devices/nanopineo3.sh
@@ -9,6 +9,7 @@ DEVICE_STATUS="P"         # First letter (Planned|Test|Maintenance)
 BASE="Debian"
 ARCH="armhf"
 BUILD="armv7"
+UINITRD_ARCH="arm64"
 
 ### Device information
 DEVICENAME="Nanopi Neo3"
@@ -36,7 +37,7 @@ INIT_TYPE="init.nextarm" # init.{x86/nextarm/nextarm_tvbox}
 # Modules that will be added to intramsfs
 MODULES=("overlay" "squashfs" "nls_cp437")
 # Packages that will be installed
-PACKAGES=("u-boot-tools" "device-tree-compiler")
+# PACKAGES=("u-boot-tools" "device-tree-compiler")
 
 ### Device customisation
 # Copy the device specific files (Image/DTS/etc..)
@@ -92,19 +93,16 @@ EOF
 
 # Will be run in chroot - Post initramfs
 device_chroot_tweaks_post() {
-  log "Running device_chroot_tweaks_post" "ext"
-
-  log "Creating uInitrd from 'volumio.initrd'" "info"
-  #TODO This can be done outside chroot,
-  # removing the need of each image needing u-boot-tools
-  # saving some time!
-  mkimage -v -A arm64 -O linux -T ramdisk -C none -a 0 -e 0 -n uInitrd -d /boot/volumio.initrd /boot/uInitrd
-  log "Removing unnecessary /boot files"
-  rm /boot/volumio.initrd
+  # log "Running device_chroot_tweaks_post" "ext"
+  :
 }
 
 # Will be called by the image builder post the chroot, before finalisation
 device_image_tweaks_post() {
-  # log "Running device_chroot_tweaks_post" "ext"
-  :
+  log "Running device_image_tweaks_post" "ext"
+  log "Creating uInitrd from 'volumio.initrd'" "info"
+  if [[ -f "${ROOTFSMNT}"/boot/volumio.initrd ]]; then
+    mkimage -v -A "${UINITRD_ARCH}" -O linux -T ramdisk -C none -a 0 -e 0 -n uInitrd -d "${ROOTFSMNT}"/boot/volumio.initrd "${ROOTFSMNT}"/boot/uInitrd
+    rm "${ROOTFSMNT}"/boot/volumio.initrd
+  fi
 }

--- a/recipes/devices/odroidxu4.sh
+++ b/recipes/devices/odroidxu4.sh
@@ -9,6 +9,7 @@ DEVICE_STATUS="P"       # First letter (Planned|Test|Maintenance)
 BASE="Debian"
 ARCH="armhf"
 BUILD="armv7"
+UINITRD_ARCH="arm"
 
 ### Device information
 DEVICENAME="Odroid-XU4"
@@ -34,7 +35,7 @@ INIT_TYPE="init.nextarm" # init.{x86/nextarm/nextarm_tvbox}
 # Modules that will be added to intramsfs
 MODULES=("overlay" "squashfs" "nls_cp437")
 # Packages that will be installed
-PACKAGES=("u-boot-tools")
+# PACKAGES=("u-boot-tools")
 
 ### Device customisation
 # Copy the device specific files (Image/DTS/etc..)
@@ -114,20 +115,16 @@ EOF
 
 # Will be run in chroot - Post initramfs
 device_chroot_tweaks_post() {
-  log "Running device_chroot_tweaks_post" "ext"
-
-  #TODO This can be done outside chroot,
-  # removing the need of each image needing u-boot-tools
-  # saving some time!
-  if [[ -f /boot/volumio.initrd ]]; then
-    log "Creating uInitrd from 'volumio.initrd'" "info"
-    mkimage -v -A arm -O linux -T ramdisk -C none -a 0 -e 0 -n uInitrd -d /boot/volumio.initrd /boot/uInitrd
-    rm /boot/volumio.initrd
-  fi
+  # log "Running device_chroot_tweaks_post" "ext"
+  :
 }
 
 # Will be called by the image builder post the chroot, before finalisation
 device_image_tweaks_post() {
-  # log "Running device_chroot_tweaks_post" "ext"
-  :
+  log "Running device_image_tweaks_post" "ext"
+  log "Creating uInitrd from 'volumio.initrd'" "info"
+  if [[ -f "${ROOTFSMNT}"/boot/volumio.initrd ]]; then
+    mkimage -v -A "${UINITRD_ARCH}" -O linux -T ramdisk -C none -a 0 -e 0 -n uInitrd -d "${ROOTFSMNT}"/boot/volumio.initrd "${ROOTFSMNT}"/boot/uInitrd
+    rm "${ROOTFSMNT}"/boot/volumio.initrd
+  fi
 }

--- a/recipes/devices/odroidxu4.sh
+++ b/recipes/devices/odroidxu4.sh
@@ -125,3 +125,9 @@ device_chroot_tweaks_post() {
     rm /boot/volumio.initrd
   fi
 }
+
+# Will be called by the image builder post the chroot, before finalisation
+device_image_tweaks_post() {
+  # log "Running device_chroot_tweaks_post" "ext"
+  :
+}

--- a/recipes/devices/orangepilite.sh
+++ b/recipes/devices/orangepilite.sh
@@ -80,6 +80,7 @@ device_chroot_tweaks_pre() {
 
 # Will be run in chroot - Post initramfs
 device_chroot_tweaks_post() {
+  # log "Running device_chroot_tweaks_post" "ext"
   :
 }
 

--- a/recipes/devices/orangepilite.sh
+++ b/recipes/devices/orangepilite.sh
@@ -92,3 +92,9 @@ device_chroot_tweaks_post() {
     mkimage -A arm -T script -C none -d /boot/boot.cmd /boot/boot.scr
   fi
 }
+
+# Will be called by the image builder post the chroot, before finalisation
+device_image_tweaks_post() {
+  # log "Running device_chroot_tweaks_post" "ext"
+  :
+}

--- a/recipes/devices/orangepilite.sh
+++ b/recipes/devices/orangepilite.sh
@@ -94,6 +94,6 @@ device_image_tweaks_post() {
   fi
   if [[ -f "${ROOTFSMNT}"/boot/boot.cmd ]]; then
     log "Creating boot.scr"
-    mkimage -A "${UINITRD_ARCH}" -T script -C none -d "${ROOTFSMNT}"/boot/boot.cmd "${ROOTFSMNT}"/boot/boot.scr
+    mkimage -A arm -T script -C none -d "${ROOTFSMNT}"/boot/boot.cmd "${ROOTFSMNT}"/boot/boot.scr
   fi
 }

--- a/recipes/devices/orangepilite.sh
+++ b/recipes/devices/orangepilite.sh
@@ -12,6 +12,7 @@ DEVICE_STATUS="P"       # First letter (Planned|Test|Maintenance)
 BASE="Debian"
 ARCH="armhf"
 BUILD="armv7"
+UINITRD_ARCH="arm"
 
 ### Device information
 DEVICENAME="Orange Pi" # Pretty name
@@ -36,7 +37,7 @@ INIT_TYPE="init.nextarm" # init.{x86/nextarm/nextarm_tvbox}
 # Modules that will be added to intramsfs
 MODULES=("overlay" "overlayfs" "squashfs" "nls_cp437")
 # Packages that will be installed
-PACKAGES=("u-boot-tools")
+# PACKAGES=("u-boot-tools")
 
 ### Device customisation
 # Copy the device specific files (Image/DTS/etc..)
@@ -79,22 +80,19 @@ device_chroot_tweaks_pre() {
 
 # Will be run in chroot - Post initramfs
 device_chroot_tweaks_post() {
-  log "Running device_chroot_tweaks_post" "ext"
-
-  #TODO This can be done outside chroot,
-  # removing the need of each image needing u-boot-tools saving some time!
-  log "Creating uInitrd from 'volumio.initrd'" "info"
-  if [[ -f /boot/volumio.initrd ]]; then
-    mkimage -v -A arm -O linux -T ramdisk -C none -a 0 -e 0 -n uInitrd -d /boot/volumio.initrd /boot/uInitrd
-  fi
-  if [[ -f /boot/boot.cmd ]]; then
-    log "Creating boot.scr"
-    mkimage -A arm -T script -C none -d /boot/boot.cmd /boot/boot.scr
-  fi
+  :
 }
 
 # Will be called by the image builder post the chroot, before finalisation
 device_image_tweaks_post() {
-  # log "Running device_chroot_tweaks_post" "ext"
-  :
+  log "Running device_image_tweaks_post" "ext"
+  log "Creating uInitrd from 'volumio.initrd'" "info"
+  if [[ -f "${ROOTFSMNT}"/boot/volumio.initrd ]]; then
+    mkimage -v -A "${UINITRD_ARCH}" -O linux -T ramdisk -C none -a 0 -e 0 -n uInitrd -d "${ROOTFSMNT}"/boot/volumio.initrd "${ROOTFSMNT}"/boot/uInitrd
+    rm "${ROOTFSMNT}"/boot/volumio.initrd
+  fi
+  if [[ -f "${ROOTFSMNT}"/boot/boot.cmd ]]; then
+    log "Creating boot.scr"
+    mkimage -A "${UINITRD_ARCH}" -T script -C none -d "${ROOTFSMNT}"/boot/boot.cmd "${ROOTFSMNT}"/boot/boot.scr
+  fi
 }

--- a/recipes/devices/pi.sh
+++ b/recipes/devices/pi.sh
@@ -377,3 +377,9 @@ device_chroot_tweaks_pre() {
 device_chroot_tweaks_post() {
 	:
 }
+
+# Will be called by the image builder post the chroot, before finalisation
+device_image_tweaks_post() {
+	# log "Running device_chroot_tweaks_post" "ext"
+	:
+}

--- a/recipes/devices/pi.sh
+++ b/recipes/devices/pi.sh
@@ -375,11 +375,12 @@ device_chroot_tweaks_pre() {
 
 # Will be run in chroot - Post initramfs
 device_chroot_tweaks_post() {
+	# log "Running device_chroot_tweaks_post" "ext"
 	:
 }
 
 # Will be called by the image builder post the chroot, before finalisation
 device_image_tweaks_post() {
-	# log "Running device_chroot_tweaks_post" "ext"
+	# log "Running device_image_tweaks_post" "ext"
 	:
 }

--- a/recipes/devices/rock64.sh
+++ b/recipes/devices/rock64.sh
@@ -107,3 +107,9 @@ device_chroot_tweaks_post() {
   log "Removing unnecessary /boot files"
   rm /boot/volumio.initrd
 }
+
+# Will be called by the image builder post the chroot, before finalisation
+device_image_tweaks_post() {
+  # log "Running device_chroot_tweaks_post" "ext"
+  :
+}

--- a/recipes/devices/rock64.sh
+++ b/recipes/devices/rock64.sh
@@ -9,6 +9,7 @@ DEVICE_STATUS="P"       # First letter (Planned|Test|Maintenance)
 BASE="Debian"
 ARCH="armhf"
 BUILD="armv7"
+UINITRD_ARCH="arm64"
 
 ### Device information
 DEVICENAME="Rock64"
@@ -100,16 +101,16 @@ EOF
 
 # Will be run in chroot - Post initramfs
 device_chroot_tweaks_post() {
-  log "Running device_chroot_tweaks_post" "ext"
-
-  log "Creating uInitrd from 'volumio.initrd'" "info"
-  mkimage -v -A arm64 -O linux -T ramdisk -C none -a 0 -e 0 -n uInitrd -d /boot/volumio.initrd /boot/uInitrd
-  log "Removing unnecessary /boot files"
-  rm /boot/volumio.initrd
+  # log "Running device_chroot_tweaks_post" "ext"
+  :
 }
 
 # Will be called by the image builder post the chroot, before finalisation
 device_image_tweaks_post() {
-  # log "Running device_chroot_tweaks_post" "ext"
-  :
+  log "Running device_image_tweaks_post" "ext"
+  log "Creating uInitrd from 'volumio.initrd'" "info"
+  if [[ -f "${ROOTFSMNT}"/boot/volumio.initrd ]]; then
+    mkimage -v -A "${UINITRD_ARCH}" -O linux -T ramdisk -C none -a 0 -e 0 -n uInitrd -d "${ROOTFSMNT}"/boot/volumio.initrd "${ROOTFSMNT}"/boot/uInitrd
+    rm "${ROOTFSMNT}"/boot/volumio.initrd
+  fi
 }

--- a/recipes/devices/rock64.sh
+++ b/recipes/devices/rock64.sh
@@ -36,7 +36,7 @@ INIT_TYPE="init.nextarm" # init.{x86/nextarm/nextarm_tvbox}
 # Modules that will be added to intramsfs
 MODULES=("overlay" "squashfs" "nls_cp437")
 # Packages that will be installed
-PACKAGES=("u-boot-tools" "device-tree-compiler" "liblircclient0" "lirc")
+PACKAGES=("device-tree-compiler" "liblircclient0" "lirc")
 
 ### Device customisation
 # Copy the device specific files (Image/DTS/etc..)

--- a/recipes/devices/rockpis.sh
+++ b/recipes/devices/rockpis.sh
@@ -97,3 +97,9 @@ device_chroot_tweaks_post() {
     mkimage -A $ARCH -T script -C none -d /boot/boot.cmd /boot/boot.scr
   fi
 }
+
+# Will be called by the image builder post the chroot, before finalisation
+device_image_tweaks_post() {
+  # log "Running device_chroot_tweaks_post" "ext"
+  :
+}

--- a/recipes/devices/rockpis.sh
+++ b/recipes/devices/rockpis.sh
@@ -96,6 +96,6 @@ device_image_tweaks_post() {
   fi
   if [[ -f "${ROOTFSMNT}"/boot/boot.cmd ]]; then
     log "Creating boot.scr"
-    mkimage -A "${UINITRD_ARCH}" -T script -C none -d "${ROOTFSMNT}"/boot/boot.cmd "${ROOTFSMNT}"/boot/boot.scr
+    mkimage -A arm -T script -C none -d "${ROOTFSMNT}"/boot/boot.cmd "${ROOTFSMNT}"/boot/boot.scr
   fi
 }

--- a/recipes/devices/rockpis.sh
+++ b/recipes/devices/rockpis.sh
@@ -82,6 +82,7 @@ device_chroot_tweaks_pre() {
 
 # Will be run in chroot - Post initramfs
 device_chroot_tweaks_post() {
+  # log "Running device_chroot_tweaks_post" "ext"
   :
 }
 

--- a/recipes/devices/tinkerboard.sh
+++ b/recipes/devices/tinkerboard.sh
@@ -36,7 +36,7 @@ INIT_TYPE="init.nextarm" # init.{x86/nextarm/nextarm_tvbox}
 # Modules that will be added to intramsfs
 MODULES=("overlay" "overlayfs" "squashfs" "nls_cp437")
 # Packages that will be installed
-PACKAGES=("u-boot-tools" "plymouth" "plymouth-themes")
+PACKAGES=("plymouth" "plymouth-themes")
 
 ### Device customisation
 # Copy the device specific files (Image/DTS/etc..)

--- a/recipes/devices/tinkerboard.sh
+++ b/recipes/devices/tinkerboard.sh
@@ -116,3 +116,9 @@ device_chroot_tweaks_post() {
     rm /boot/volumio.initrd
   fi
 }
+
+# Will be called by the image builder post the chroot, before finalisation
+device_image_tweaks_post() {
+  # log "Running device_chroot_tweaks_post" "ext"
+  :
+}

--- a/recipes/devices/tinkerboard.sh
+++ b/recipes/devices/tinkerboard.sh
@@ -9,6 +9,7 @@ DEVICE_STATUS="T"       # First letter (Planned|Test|Maintenance)
 BASE="Debian"
 ARCH="armhf"
 BUILD="armv7"
+UINITRD_ARCH="arm"
 
 ### Device information
 DEVICENAME="Asus Tinkerboard"
@@ -105,20 +106,16 @@ device_chroot_tweaks_pre() {
 
 # Will be run in chroot - Post initramfs
 device_chroot_tweaks_post() {
-  log "Running device_chroot_tweaks_post" "ext"
-
-  #TODO This can be done outside chroot,
-  # removing the need of each image needing u-boot-tools
-  # saving some time!
-  if [[ -f /boot/volumio.initrd ]]; then
-    log "Creating uInitrd from 'volumio.initrd'" "info"
-    mkimage -v -A arm -O linux -T ramdisk -C none -a 0 -e 0 -n uInitrd -d /boot/volumio.initrd /boot/uInitrd
-    rm /boot/volumio.initrd
-  fi
+  # log "Running device_chroot_tweaks_post" "ext"
+  :
 }
 
 # Will be called by the image builder post the chroot, before finalisation
 device_image_tweaks_post() {
-  # log "Running device_chroot_tweaks_post" "ext"
-  :
+  log "Running device_image_tweaks_post" "ext"
+  log "Creating uInitrd from 'volumio.initrd'" "info"
+  if [[ -f "${ROOTFSMNT}"/boot/volumio.initrd ]]; then
+    mkimage -v -A "${UINITRD_ARCH}" -O linux -T ramdisk -C none -a 0 -e 0 -n uInitrd -d "${ROOTFSMNT}"/boot/volumio.initrd "${ROOTFSMNT}"/boot/uInitrd
+    rm "${ROOTFSMNT}"/boot/volumio.initrd
+  fi
 }

--- a/recipes/devices/vszero.sh
+++ b/recipes/devices/vszero.sh
@@ -2,8 +2,8 @@
 # shellcheck disable=SC2034
 
 ## Setup for Polyvection Voltastream Zero  (Community Portings)
-DEVICE_SUPPORT_TYPE="C"   # First letter (Community Porting|Supported Officially|OEM)
-DEVICE_STATUS="P"         # First letter (Planned|Test|Maintenance)
+DEVICE_SUPPORT_TYPE="C" # First letter (Community Porting|Supported Officially|OEM)
+DEVICE_STATUS="P"       # First letter (Planned|Test|Maintenance)
 
 ## Images will not be pusblished
 
@@ -31,8 +31,8 @@ VOLINITUPDATER=yes
 ## Partition info
 BOOT_START=1
 BOOT_END=64
-BOOT_TYPE=msdos          # msdos or gpt
-BOOT_USE_UUID=no         # Add UUID to fstab
+BOOT_TYPE=msdos  # msdos or gpt
+BOOT_USE_UUID=no # Add UUID to fstab
 INIT_TYPE="init" # init.{x86/nextarm/nextarm_tvbox}
 
 # Modules that will be added to intramsfs
@@ -48,7 +48,6 @@ write_device_files() {
   cp -dR "${PLTDIR}/${DEVICEBASE}/boot" "${ROOTFSMNT}"
   cp -pdR "${PLTDIR}/${DEVICEBASE}/lib/modules" "${ROOTFSMNT}/lib"
   cp -dR "${PLTDIR}/${DEVICEBASE}/lib/firmware" "${ROOTFSMNT}/lib/"
-
 
   log "Add hotspot"
   cp "${PLTDIR}/${DEVICEBASE}/bin/hotspot.sh" "${ROOTFSMNT}/bin"
@@ -90,4 +89,10 @@ device_chroot_tweaks_post() {
   mkimage -v -A arm -O linux -T ramdisk -C none -a 0 -e 0 -n uInitrd -d /boot/volumio.initrd /boot/uInitrd
   log "Removing unnecessary /boot files"
   rm /boot/volumio.initrd
+}
+
+# Will be called by the image builder post the chroot, before finalisation
+device_image_tweaks_post() {
+  # log "Running device_chroot_tweaks_post" "ext"
+  :
 }

--- a/recipes/devices/vszero.sh
+++ b/recipes/devices/vszero.sh
@@ -39,7 +39,7 @@ INIT_TYPE="init" # init.{x86/nextarm/nextarm_tvbox}
 # Modules that will be added to intramsfs
 MODULES=("overlay" "squashfs" "nls_cp437")
 # Packages that will be installed
-PACKAGES=("u-boot-tools")
+# PACKAGES=("u-boot-tools")
 
 ### Device customisation
 # Copy the device specific files (Image/DTS/etc..)

--- a/recipes/devices/vszero.sh
+++ b/recipes/devices/vszero.sh
@@ -12,6 +12,7 @@ DEVICE_STATUS="P"       # First letter (Planned|Test|Maintenance)
 BASE="Debian"
 ARCH="armhf"
 BUILD="armv7"
+UINITRD_ARCH="arm"
 
 ### Device information
 DEVICENAME="Voltastream Zero"
@@ -83,16 +84,16 @@ device_chroot_tweaks_pre() {
 
 # Will be run in chroot - Post initramfs
 device_chroot_tweaks_post() {
-  log "Running device_chroot_tweaks_post" "ext"
-
-  log "Creating uInitrd from 'volumio.initrd'" "info"
-  mkimage -v -A arm -O linux -T ramdisk -C none -a 0 -e 0 -n uInitrd -d /boot/volumio.initrd /boot/uInitrd
-  log "Removing unnecessary /boot files"
-  rm /boot/volumio.initrd
+  # log "Running device_chroot_tweaks_post" "ext"
+  :
 }
 
 # Will be called by the image builder post the chroot, before finalisation
 device_image_tweaks_post() {
-  # log "Running device_chroot_tweaks_post" "ext"
-  :
+  log "Running device_image_tweaks_post" "ext"
+  log "Creating uInitrd from 'volumio.initrd'" "info"
+  if [[ -f "${ROOTFSMNT}"/boot/volumio.initrd ]]; then
+    mkimage -v -A "${UINITRD_ARCH}" -O linux -T ramdisk -C none -a 0 -e 0 -n uInitrd -d "${ROOTFSMNT}"/boot/volumio.initrd "${ROOTFSMNT}"/boot/uInitrd
+    rm "${ROOTFSMNT}"/boot/volumio.initrd
+  fi
 }

--- a/scripts/makeimage.sh
+++ b/scripts/makeimage.sh
@@ -236,6 +236,9 @@ end_chroot_final=$(date +%s)
 time_it "$end_chroot_final" "$start_chroot_final"
 log "Finished chroot image configuration" "okay" "$TIME_STR"
 
+log "Entering device_image_tweaks_post" "cfg"
+device_image_tweaks_post
+
 log "Finalizing Rootfs (Cleaning, Stripping, Hashing)" "info"
 # shellcheck source=./scripts/volumio/finalize.sh
 source "${SRC}/scripts/volumio/finalize.sh"


### PR DESCRIPTION
Fixing an old `TODO`

#### All devices
-- Add a `device_image_tweaks_post`  to the templates that is invoked by `makeimage` post the chroot stuff, before `finalize` to run any device specific tweaks.

#### OpiLite, NanoPiNeo2, RockPiS (aka devices I can test) 
-- Use this to run `mkimage` outside the chroot, so that we don't need to install `u-boot-tools` during device level chroot configuration. 
-- Add `UINITRD_ARCH` into device templates so it's explicit if our device has an `armv7` or `amv8` cpu. 

Can also go ahead and update the rest of the devices, but can't test them.. 

