### PR TITLE
Add OrangePi H3 based family

### DIFF
--- a/recipes/devices/README.MD
+++ b/recipes/devices/README.MD
@@ -20,7 +20,7 @@ Most devices rely on the community to test, debug and maintain :-)
 | odroidc4     | armv7 | armhf | odroidc4             | Odroid-C4            | [4.9.y](https://github.com/volumio/platform-odroid.git)    | C    | P      |
 | odroidn2     | armv7 | armhf | odroidn2             | Odroid-N2            | [4.9.y](https://github.com/volumio/platform-odroid.git)    | C    | P      |
 | odroidxu4    | armv7 | armhf | odroidxu4            | Odroid-XU4           | [4.9.y](https://github.com/volumio/platform-odroid.git)    | C    | P      |
-| orangepilite | armv7 | armhf | orangepilite         | Orange Pi            | [5.4.y](https://github.com/ashthespy/platform-orangepi)    | C    | T      |
+| orangepilite | armv7 | armhf | orangepilite         | Orange Pi            | [5.4.y](https://github.com/volumio/platform-orangepi)      | C    | T      |
 | pine64base   | armv7 | armhf | pine64               | Pine64               | [5.7.y](https://github.com/volumio/platform-pine64.git)    | C    | P      |
 | pine64plus   | armv7 | armhf | pine64plus           | Pine64+              | [5.7.y](https://github.com/volumio/platform-pine64.git)    | C    | P      |
 | pine64solts  | armv7 | armhf | pine64solts          | soPine64-Pine64LTS   | [5.7.y](https://github.com/volumio/platform-pine64.git)    | C    | P      |

--- a/recipes/devices/families/orangepi_h3.sh
+++ b/recipes/devices/families/orangepi_h3.sh
@@ -16,7 +16,7 @@ UINITRD_ARCH="arm" # Instruct mkimage to use the correct architecture on arm{64}
 DEVICEFAMILY="orangepi"
 # tarball from DEVICEFAMILY repo to use
 #DEVICEBASE=${DEVICE} # Defaults to ${DEVICE} if unset
-DEVICEREPO="https://github.com/ashthespy/platform-${DEVICEFAMILY}"
+DEVICEREPO="https://github.com/volumio/platform-${DEVICEFAMILY}"
 
 ### What features do we want to target
 # TODO: Not fully implement

--- a/recipes/devices/families/orangepi_h3.sh
+++ b/recipes/devices/families/orangepi_h3.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+# shellcheck disable=SC2034
+
+## Setup for Orange Pi H3 based devices
+DEVICE_SUPPORT_TYPE="C" # First letter (Community Porting|Supported Officially|OEM)
+DEVICE_STATUS="P"       # First letter (Planned|Test|Maintenance)
+
+# Base system
+BASE="Debian"
+ARCH="armhf"
+BUILD="armv7"
+UINITRD_ARCH="arm" # Instruct mkimage to use the correct architecture on arm{64} devices
+
+### Device information
+# This is useful for multiple devices sharing the same/similar kernel
+DEVICEFAMILY="orangepi"
+# tarball from DEVICEFAMILY repo to use
+#DEVICEBASE=${DEVICE} # Defaults to ${DEVICE} if unset
+DEVICEREPO="https://github.com/ashthespy/platform-${DEVICEFAMILY}"
+
+### What features do we want to target
+# TODO: Not fully implement
+VOLVARIANT=no # Custom Volumio (Motivo/Primo etc)
+MYVOLUMIO=no
+VOLINITUPDATER=yes
+
+## Partition info
+BOOT_START=1
+BOOT_END=64
+BOOT_TYPE=msdos          # msdos or gpt
+INIT_TYPE="init.nextarm" # init.{x86/nextarm/nextarm_tvbox}
+
+# Modules that will be added to intramsfs
+MODULES=("overlay" "overlayfs" "squashfs" "nls_cp437")
+# Packages that will be installed
+# PACKAGES=("u-boot-tools")
+
+### Device customisation
+# Copy the device specific files (Image/DTS/etc..)
+write_device_files() {
+  log "Running write_device_files" "ext"
+
+  cp -dR "${PLTDIR}/${DEVICE}/boot" "${ROOTFSMNT}"
+  cp -pdR "${PLTDIR}/${DEVICE}/lib/modules" "${ROOTFSMNT}/lib"
+  cp -pdR "${PLTDIR}/${DEVICE}/lib/firmware" "${ROOTFSMNT}/lib"
+}
+
+write_device_bootloader() {
+  log "Running write_device_bootloader" "ext"
+
+  dd if="${PLTDIR}/${DEVICE}/u-boot/u-boot-sunxi-with-spl.bin" of="${LOOP_DEV}" bs=1024 seek=8 conv=notrunc
+}
+
+# Will be called by the image builder for any customisation
+device_image_tweaks() {
+  :
+}
+
+# Will be run in chroot - Pre initramfs
+device_chroot_tweaks_pre() {
+  log "Performing device_chroot_tweaks_pre" "ext"
+
+  log "Adding gpio group and udev rules"
+  groupadd -f --system gpio
+  usermod -aG gpio volumio
+  # Works with newer kernels as well
+  cat <<-EOF >/etc/udev/rules.d/99-gpio.rules
+	SUBSYSTEM=="gpio*", PROGRAM="/bin/sh -c 'find -L /sys/class/gpio/ -maxdepth 2 -exec chown root:gpio {} \; -exec chmod 770 {} \; || true'"
+	EOF
+}
+
+# Will be run in chroot - Post initramfs
+device_chroot_tweaks_post() {
+  # log "Running device_chroot_tweaks_post" "ext"
+  :
+}
+
+# Will be called by the image builder post the chroot, before finalisation
+device_image_tweaks_post() {
+  log "Running device_image_tweaks_post" "ext"
+  log "Creating uInitrd from 'volumio.initrd'" "info"
+  if [[ -f "${ROOTFSMNT}"/boot/volumio.initrd ]]; then
+    mkimage -v -A "${UINITRD_ARCH}" -O linux -T ramdisk -C none -a 0 -e 0 -n uInitrd -d "${ROOTFSMNT}"/boot/volumio.initrd "${ROOTFSMNT}"/boot/uInitrd
+    rm "${ROOTFSMNT}"/boot/volumio.initrd
+  fi
+  if [[ -f "${ROOTFSMNT}"/boot/boot.cmd ]]; then
+    log "Creating boot.scr"
+    mkimage -A arm -T script -C none -d "${ROOTFSMNT}"/boot/boot.cmd "${ROOTFSMNT}"/boot/boot.scr
+  fi
+}

--- a/recipes/devices/orangepione.sh
+++ b/recipes/devices/orangepione.sh
@@ -9,4 +9,4 @@ DEVICE_STATUS="T"       # First letter (Planned|Test|Maintenance)
 source "${SRC}"/recipes/devices/families/orangepi_h3.sh
 
 ### Device information
-DEVICENAME="Orange Pi Lite" # Pretty name
+DEVICENAME="Orange Pi One" # Pretty name

--- a/recipes/devices/orangepipc.sh
+++ b/recipes/devices/orangepipc.sh
@@ -9,4 +9,4 @@ DEVICE_STATUS="T"       # First letter (Planned|Test|Maintenance)
 source "${SRC}"/recipes/devices/families/orangepi_h3.sh
 
 ### Device information
-DEVICENAME="Orange Pi Lite" # Pretty name
+DEVICENAME="Orange Pi PC" # Pretty name


### PR DESCRIPTION
Finalise support for OrangePiOne and OrangePiPC.
Bumped from the sunxi's 5.4 to 5.10.y kennel and my OpiLite still works fine. 
The Opi One and PC I don't have to test, but it looks like @Vyacheslav-S has already [provided some test Buster images](https://community.volumio.org/t/volumio-debian-buster-beta-orange-pi-images/44826) although I am unsure with which platform files. 