### PR TITLE
Pull in the latest MPD

### DIFF
--- a/recipes/base/VolumioBase.conf
+++ b/recipes/base/VolumioBase.conf
@@ -93,10 +93,16 @@ keyring=debian-archive-keyring
 suite=buster-backports
 
 [Volumio]
-packages=mpc mpd 
+packages=mpc 
 source=http://deb.debian.org/debian
 keyring=debian-archive-keyring
 suite=buster
+
+[MPD]
+packages=mpd 
+source=https://deb.kaliko.me/raspbian-backports/
+keyring=debian-archive-keyring
+suite=buster-backports
 
 [Kiosk]
 packages=chromium chromium-l10n fonts-arphic-gbsn00lp fonts-arphic-ukai fonts-unfonts-core openbox unclutter xinit xorg

--- a/recipes/base/arm.conf
+++ b/recipes/base/arm.conf
@@ -3,7 +3,7 @@
 # to use pi's debian source containing packages built for armhf with ARMv6 ISA(VFP2) instead of Debian's ARMv7 ISA(VFP3) 
 include=arm-raspbian.conf 
 # only pick what we need from VolumioBase
-debootstrap=Base Net Utils Assets FS Firmware Accessories Volumio BaseDebPlus UpmpdcliDependencies ShairportSyncDependencies
+debootstrap=Base Net Utils Assets FS Firmware Accessories Volumio MPD BaseDebPlus UpmpdcliDependencies ShairportSyncDependencies
 
 # Add additional Raspberry Pi specific packages (if required)
 

--- a/recipes/base/armv7.conf
+++ b/recipes/base/armv7.conf
@@ -1,6 +1,6 @@
 [General]
 include=VolumioBase.conf 
 # only pick what we need from VolumioBase
-debootstrap=Base BaseDebPlus Net Utils Assets FS Firmware Accessories Volumio UpmpdcliDependencies ShairportSyncDependencies
+debootstrap=Base BaseDebPlus Net Utils Assets FS Firmware Accessories Volumio MPD UpmpdcliDependencies ShairportSyncDependencies
 
 # Add additional armv7 specific packages (if required)

--- a/recipes/base/armv8.conf
+++ b/recipes/base/armv8.conf
@@ -1,6 +1,6 @@
 [General]
 include=VolumioBase.conf 
 # only pick what we need from VolumioBase
-debootstrap=Base BaseDebPlus Net Utils Assets FS Firmware Accessories Volumio ShairportSyncDependencies
+debootstrap=Base BaseDebPlus Net Utils Assets FS Firmware Accessories Volumio MPD ShairportSyncDependencies
 
 # Add additional armv8 specific packages (if required)

--- a/recipes/base/x86.conf
+++ b/recipes/base/x86.conf
@@ -1,7 +1,7 @@
 [General]
 include=VolumioBase.conf 
 # only pick what we need from VolumioBase
-debootstrap=Base Net Utils Assets FS Firmware Accessories Volumio BasePlus Kiosk UpmpdcliDependencies ShairportSyncDependencies
+debootstrap=Base Net Utils Assets FS Firmware Accessories Volumio MPDx86 BasePlus Kiosk UpmpdcliDependencies ShairportSyncDependencies
 
 # Add additional x86 specific packages (if required)
 
@@ -10,3 +10,9 @@ packages=gdisk grub-common initramfs-tools pciutils plymouth plymouth-themes sys
 source=http://deb.debian.org/debian
 keyring=debian-archive-keyring
 suite=buster
+
+[MPDx86]
+packages=mpd 
+source=https://deb.kaliko.me/debian-backports/
+keyring=debian-archive-keyring
+suite=buster-backports

--- a/scripts/config.sh
+++ b/scripts/config.sh
@@ -5,6 +5,7 @@ declare -A SecureApt=(
   [debian_10.gpg]="https://ftp-master.debian.org/keys/archive-key-10.asc"
   [nodesource.gpg]="https://deb.nodesource.com/gpgkey/nodesource.gpg.key"
   [lesbonscomptes.gpg]="https://www.lesbonscomptes.com/pages/jf-at-dockes.org.pub"
+  [deb.kaliko.me.gpg]="https://media.kaliko.me/kaliko.gpg"
   #TODO Not needed for arm64 and x86
   [raspbian.gpg]="https://archive.raspbian.org/raspbian.public.key"
   [raspberrypi.gpg]="http://archive.raspberrypi.org/debian/raspberrypi.gpg.key"


### PR DESCRIPTION
This commit switches MPD installation to use the apt repository recommended by the MPD team because it is kept up to date with the MPD release. 

The version in buster is several years old and does not work when the multiroom is enabled (even when multiroom isn't being used).

Note that there are two repositories, one which has `amd64` binaries, and one which has `armhf` binaries. The `armhf` binaries are all raspbian compatible (i.e. compiled for armV6 floating point) but still work on non raspbian armV7 targets (tested on tinkerboard).