### PR TITLE
Enable rt5640 jackdetect

### DIFF
--- a/recipes/base/x86.conf
+++ b/recipes/base/x86.conf
@@ -1,18 +1,18 @@
 [General]
-include=VolumioBase.conf 
+include=VolumioBase.conf
 # only pick what we need from VolumioBase
 debootstrap=Base Net Utils Assets FS Firmware Accessories Volumio MPDx86 BasePlus Kiosk UpmpdcliDependencies ShairportSyncDependencies
 
 # Add additional x86 specific packages (if required)
 
 [BasePlus]
-packages=gdisk grub-common initramfs-tools pciutils plymouth plymouth-themes syslinux syslinux-common dmidecode inxi lshw
+packages=gdisk grub-common initramfs-tools pciutils plymouth plymouth-themes syslinux syslinux-common acpid dmidecode inxi lshw
 source=http://deb.debian.org/debian
 keyring=debian-archive-keyring
 suite=buster
 
 [MPDx86]
-packages=mpd 
+packages=mpd
 source=https://deb.kaliko.me/debian-backports/
 keyring=debian-archive-keyring
 suite=buster-backports

--- a/recipes/devices/families/x86.sh
+++ b/recipes/devices/families/x86.sh
@@ -84,6 +84,7 @@ write_device_files() {
   mkdir -p "${ROOTFSMNT}"/usr/local/bin/
   declare -A CustomScripts=(
     [bytcr_init.sh]="bytcr-init/bytcr-init.sh"
+    [jackdetect-rt5640.sh]="bytcr-init/jackdetect-rt5640.sh"
     [volumio_hda_intel_tweak.sh]="hda-intel-tweaks/volumio_hda_intel_tweak.sh"
     [x86Installer.sh]="x86Installer/x86Installer.sh"
   )
@@ -116,7 +117,10 @@ write_device_files() {
   ]
 }
 EOF
-
+  # Headphone detect currently only for atom z8350 with rt5640 codec
+  # Evaluate additional requirements when they arrive
+  log "Copying acpi event handing for headphone jack detect (z8350 with rt5640 only)"
+  cp "${pkg_root}"/bytcr-init/jackdetect "${ROOTFSMNT}"/etc/acpi/events
 }
 
 write_device_bootloader() {
@@ -151,6 +155,9 @@ ExecStart=/usr/local/bin/soundcard-init.sh
 WantedBy=multi-user.target
 EOF
   ln -s "${ROOTFSMNT}/lib/systemd/system/soundcard-init.service" "${ROOTFSMNT}/etc/systemd/system/multi-user.target.wants/soundcard-init.service"
+
+  #log "Adding ACPID Service to Startup"
+  #ln -s "${ROOTFSMNT}/lib/systemd/system/acpid.service" "${ROOTFSMNT}/etc/systemd/system/multi-user.target.wants/acpid.service"
 
   log "Blacklisting PC speaker"
   cat <<-EOF >>"${ROOTFSMNT}/etc/modprobe.d/blacklist.conf"

--- a/scripts/initramfs/init.x86
+++ b/scripts/initramfs/init.x86
@@ -307,6 +307,10 @@ fi
 print_msg "Checking for a volumio rootfs update on a USB device"
 mkdir /mnt/usb
 for devlink in /dev/sd[a-z]; do
+  if [ "${devlink}" == "/dev/sd[a-z]" ]; then
+  # no usb devices present
+    break
+  fi
   # do the first partition of a usb device, must be removable and not the boot device!
   if [ $(lsblk ${devlink} --list -no tran) == usb ] && \
      [ ${BOOT_DEVICE} != ${devlink} ]; then
@@ -332,6 +336,10 @@ done
 
 print_msg "Checking for factory reset on a USB device"
 for devlink in /dev/sd[a-z]; do
+  if [ "${devlink}" == "/dev/sd[a-z]" ]; then
+  # no usb devices present
+    break
+  fi
   # do the first partition of a usb device, must be removable and not the boot device!
   if [ $(lsblk ${devlink} --list -no tran) == usb ] && \
      [ ${BOOT_DEVICE} != ${devlink} ]; then


### PR DESCRIPTION
Enable jack detection for Intel Atom RT5640-based sound devices. 
It allows switching between speaker and headphones when plugging/unplugging the headphone jack