### PR TITLE
Introduce kernel module for WaveShare WM8960 Audio HAT

### DIFF
--- a/recipes/devices/pi.sh
+++ b/recipes/devices/pi.sh
@@ -369,7 +369,21 @@ device_chroot_tweaks_pre() {
 # Will be run in chroot - Post initramfs
 device_chroot_tweaks_post() {
 	# log "Running device_chroot_tweaks_post" "ext"
-	:
+	log "Download Kernel Sources"
+	volumio kernelsource
+	log "Install WM8960-Audio-HAT Kernel Module & Overlay"
+	git clone https://github.com/waveshare/WM8960-Audio-HAT.git /opt/WM8960
+	pushd /opt/WM8960
+	# hack system environment
+	sed -i 's/is_Raspberry=.*/is_Raspberry=Raspberry/g' install.sh
+	sed -i 's/uname_r=.*/uname_r="5.4.83+"/g' install.sh
+	# revert API to kernel version before 5.10.y
+	sed -i 's/snd_soc_component_read/snd_soc_component_read32/g' wm8960.c
+	sed -i '/\.no_capture_mute/d' wm8960.c
+	./install.sh
+	popd
+	rm -rf /opt/WM8960
+	chmod -x /lib/systemd/system/wm8960-soundcard.service
 }
 
 # Will be called by the image builder post the chroot, before finalisation


### PR DESCRIPTION
WaveShare didn't provide pre-built binaries for raspberry pi and therefore I took their source code and patch it up to build required kernel modules under `device_chroot_tweaks_post()`.

I wonder running full `volumio kernelsource` command is an overkill because I only need headers to build `dkms` modules. Also, this is a quick-and-dirty hack for demonstration purpose, so please advice if there's a better place for it.

My magic line to `/volumio/app/plugins/system_controller/i2s_dacs/dacs.json` is:
```
{"id":"wm8960-soundcard","name":"Waveshare - WM8960","overlay":"wm8960-soundcard,i2s-mmap","alsanum":"1","mixer":"","modules":"","script":"","i2c_address":"1a","needsreboot":"yes"},
```

Thanks,
Halley