### PR TITLE
Fetching pre-built artifacts for wm8960 DAC

### DIFF
--- a/recipes/devices/pi.sh
+++ b/recipes/devices/pi.sh
@@ -167,6 +167,7 @@ device_chroot_tweaks_pre() {
 		[AlloPiano]="https://github.com/allocom/piano-firmware/archive/master.tar.gz"
 		[TauDAC]="https://github.com/taudac/modules/archive/rpi-volumio-${KERNEL_VERSION}-taudac-modules.tar.gz"
 		[Bassowl]="https://raw.githubusercontent.com/Darmur/bassowl-hat/master/driver/archives/modules-rpi-${KERNEL_VERSION}-bassowl.tar.gz"
+		[wm8960]="https://raw.githubusercontent.com/hftsai256/wm8960-rpi-modules/main/wm8960-modules-rpi-${KERNEL_VERSION}.tar.gz"
 	)
 
 	### Kernel installation


### PR DESCRIPTION
This PR is re-created as discussed in the previously-closed one: [PR#512](https://github.com/volumio/Build/pull/512). The referred archive is manually collected for now, and we may need a CI/CD system for our best interest.