### PR TITLE
Fix boot error due to ldlinux.sys relocation

### DIFF
--- a/scripts/makeimage.sh
+++ b/scripts/makeimage.sh
@@ -266,7 +266,12 @@ if [ -e "${VOLMNT}/kernel_current.tar" ]; then
 fi
 
 log "Creating Kernel archive"
-tar cf "${VOLMNT}/kernel_current.tar" --exclude='resize-volumio-datapart' \
+# With x86, also exclude ldlinux.sys from kernel_current.tar, it is part of the syslinux bootloader
+# Rewriting it would result in relocation and a broken legacy boot 
+EXCLUDE_LIST="--exclude=resize-volumio-datapart "
+[[ "${DEVICEFAMILY}" == x86 ]] && EXCLUDE_LIST="${EXCLUDE_LIST} --exclude=ldlinux.sys"
+
+tar cf "${VOLMNT}/kernel_current.tar" ${EXCLUDE_LIST}\
   -C $SQSHMNT/boot/ .
 
 [[ "${CLEAN_IMAGE_FILE:-yes}" != yes ]] && cp -rp "${VOLMNT}"/kernel_current.tar "${OUTPUT_DIR}"/kernel_current.tar

--- a/scripts/makeimage.sh
+++ b/scripts/makeimage.sh
@@ -266,12 +266,11 @@ if [ -e "${VOLMNT}/kernel_current.tar" ]; then
 fi
 
 log "Creating Kernel archive"
-# With x86, also exclude ldlinux.sys from kernel_current.tar, it is part of the syslinux bootloader
-# Rewriting it would result in relocation and a broken legacy boot 
-EXCLUDE_LIST="--exclude=resize-volumio-datapart "
-[[ "${DEVICEFAMILY}" == x86 ]] && EXCLUDE_LIST="${EXCLUDE_LIST} --exclude=ldlinux.sys"
+# Also exclude ldlinux.sys from kernel_current.tar (only present with x86).
+# It is part of the x86 syslinux bootloader
+# Rewriting it would result in relocation and a broken x86 legacy boot
 
-tar cf "${VOLMNT}/kernel_current.tar" ${EXCLUDE_LIST}\
+tar cf "${VOLMNT}/kernel_current.tar" --exclude='resize-volumio-datapart' --exclude='ldlinux.sys' \
   -C $SQSHMNT/boot/ .
 
 [[ "${CLEAN_IMAGE_FILE:-yes}" != yes ]] && cp -rp "${VOLMNT}"/kernel_current.tar "${OUTPUT_DIR}"/kernel_current.tar


### PR DESCRIPTION
ldlinux.sys is part of the syslinux bootloader and gets installed at a fixed sector location in the boot partition.
It must not be moved.
When the archive file kernel_current.tar is unpacked with a ldlinux.sys present, ldlinux.sys will be rewritten and its sector location will change.
This results in the loader not being able to locate ldlinux.sys and subsequently fails with Boot error.
Therefore it must be excluding from the archive file.